### PR TITLE
Implement side effects

### DIFF
--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -251,6 +251,13 @@
     (prn 'data data)
     (assoc app ::bread/data data)))
 
+(defstate counter
+  :start (atom 0))
+
+(comment
+  ;; This should increment with every request
+  (deref counter))
+
 ;; TODO reload app automatically when src changes
 (defstate load-app
   :start (reset! app
@@ -261,6 +268,12 @@
                                 (i18n/plugin)
                                 (post/plugin)
                                 (br/plugin {:router $router})
+
+                                ;; Increment counter on every request
+                                (fn [app]
+                                  (bread/add-effect app (fn [_]
+                                                          (swap! counter inc)
+                                                          nil)))
 
                                 ;; TODO DEFAULT PLUGINS
                                 (fn [app]

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -8,7 +8,12 @@
 (s/def ::hooks map?)
 (s/def ::plugins vector?)
 
-(s/def ::app (s/keys :req [::config ::hooks ::plugins]))
+(s/def ::resolver map?)
+(s/def ::queries vector?)
+(s/def ::data map?)
+
+(s/def ::app (s/keys :req [::config ::hooks ::plugins]
+                     :opt [::resolver ::queries ::data]))
 
 (def ^{:dynamic true
        :doc

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -175,6 +175,11 @@
   ([app f]
    (add-hook app :hook/effects f {})))
 
+(defn add-effect
+  "Adds e as an Effect to be run during the apply-effects lifecycle phase."
+  [req e]
+  (update req ::effects (comp vec conj) e))
+
 (defmacro add-effects->
   "Threads app through forms after prepending `add-effect to each."
   [app' & forms]

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -181,7 +181,12 @@
   (effect!
     ([v req]
      (let [[f & args] v]
-       (apply f req args)))))
+       (apply f req args))))
+
+  java.util.concurrent.Future
+  (effect!
+    ([fut _]
+     (deref fut))))
 
 (defn add-effect
   "Adds e as an Effect to be run during the apply-effects lifecycle phase."

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -166,6 +166,7 @@
   (let [forms (map #(cons `add-hook %) forms)]
     `(-> ~app' ~@forms)))
 
+#_
 (defn add-effect
   "Adds the (presumably effectful) function f as a callback to the special
   :hook/effects hook. Accepts an optional options map."
@@ -287,6 +288,7 @@
   [app h & args]
   (apply hook-> app h app args))
 
+#_
 (defn- apply-effects [app]
   (or (hook app :hook/effects) app))
 
@@ -320,8 +322,8 @@
         (hook :hook/request)
         (hook :hook/dispatch) ;; -> ::resolver
         (hook :hook/resolve)  ;; -> ::queries
-        (hook :hook/expand)   ;; -> ::data, ::effects
-        (apply-effects)       ;; -> more ::data
+        (hook :hook/expand)   ;; -> ::data
+        #_(apply-effects)       ;; -> more ::data
         (hook :hook/render)   ;; -> standard Ring keys: :status, :headers, :body
         (hook :hook/response))))
 

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -111,6 +111,7 @@
     :db/index true
     :db/cardinality :db.cardinality/one
     :migration/key :bread.migration/initial}
+   ;; TODO i18n for taxon name and description -> :taxon/fields
    {:db/ident :taxon/name
     :db/doc "The human-readable name of the taxon"
     :db/valueType :db.type/string

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -171,7 +171,7 @@
 
 (deftest test-apply-effects-lifecycle-phase
 
-  (testing "it applies effects until none are left to apply"
+  (testing "it applies Effects until none are left to apply"
     (letfn [(count-to-three [{::bread/keys [data]}]
               (if (> 7 (:counter data))
                 {::bread/data (update data :counter inc)
@@ -185,21 +185,30 @@
             (is (= 7 (-> (handler {:uri "/"})
                          (get-in [::bread/data :counter])))))))
 
-  (testing "it ignores effects that are not functions"
-    (let [;; Once an invalid (non-fn) Effect is returned, the whole fx chain
+  (testing "it ignores Effects that are not functions"
+    (let [;; Once an invalid Effect is returned, the whole fx chain
           ;; short-circuits and no subsequent Effects are run.
           never-run #(throw (Exception. "shouldn't get here."))
           ;; This effect will be applied (i.e. its returned ::data will
           ;; be honored) but the invalid Effect(s) it adds will not.
           effect (constantly {::bread/data {:counter 1}
-                              ::bread/effects ["not a fn" never-run]})
+                              ::bread/effects ["not an Effect" never-run]})
           handler (-> (bread/app)
                       (bread/add-effect effect)
                       (assoc ::bread/data {:counter 0})
                       (bread/handler))]
       (is (= 1 (-> (handler {:uri "/"})
                    (get-in [::bread/data :counter]))))))
-  )
+
+  (testing "it accepts vectors as Effects"
+    (let [sum (fn [{::bread/keys [data]} & nums]
+                {::bread/data (assoc data :sum (reduce + nums))})
+          handler (-> (bread/app)
+                      (bread/add-effect [sum 3 2 1])
+                      (assoc ::bread/data {:sum 0})
+                      (bread/handler))]
+      (is (= 6 (-> (handler {:uri "/"})
+                   (get-in [::bread/data :sum])))))))
 
 (deftest test-add-value-hook
 

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -151,14 +151,14 @@
 (deftest test-apply-effects-lifecycle-phase
 
   (testing "it applies Effects until none are left to apply"
-    (letfn [(count-to-three [{::bread/keys [data]}]
+    (letfn [(count-to-seven [{::bread/keys [data]}]
               (if (> 7 (:counter data))
                 {::bread/data (update data :counter inc)
-                 ::bread/effects [count-to-three]}
+                 ::bread/effects [count-to-seven]}
                 {::bread/data data
                  ::bread/effects []}))]
           (let [handler (-> (bread/app)
-                            (bread/add-effect count-to-three)
+                            (bread/add-effect count-to-seven)
                             (assoc ::bread/data {:counter 0})
                             (bread/handler))]
             (is (= 7 (-> (handler {:uri "/"})

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -198,7 +198,11 @@
                       (assoc ::bread/data {:num 0})
                       (bread/handler))]
       (is (= 1 (-> (handler {:uri "/"})
-                   (get-in [::bread/data :num])))))))
+                   (get-in [::bread/data :num]))))))
+
+  ;; TODO add-tx convenience fn (for running db tx directly)
+  ;; TODO add-transform convenience fn (for effects that will chain more effects)
+  )
 
 (deftest test-add-value-hook
 

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -137,16 +137,16 @@
   (testing "it adds the given Effect to ::effects"
     (are [effects app] (= effects (::bread/effects app))
 
-         [prn] (-> (bread/app)
-                        (bread/add-effect prn))
+      [prn] (-> (bread/app)
+                     (bread/add-effect prn))
 
-         [inc] (-> (bread/app)
-                   (bread/add-effect inc))
+      [inc] (-> (bread/app)
+                (bread/add-effect inc))
 
-         [inc dec prn-str] (-> (bread/app)
-                               (bread/add-effect inc)
-                               (bread/add-effect dec)
-                               (bread/add-effect prn-str)))))
+      [inc dec prn-str] (-> (bread/app)
+                            (bread/add-effect inc)
+                            (bread/add-effect dec)
+                            (bread/add-effect prn-str)))))
 
 (deftest test-apply-effects-lifecycle-phase
 

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -200,7 +200,7 @@
       (is (= 1 (-> (handler {:uri "/"})
                    (get-in [::bread/data :counter]))))))
 
-  (testing "it accepts vectors as Effects"
+  (testing "vectors are valid Effects"
     (let [sum (fn [{::bread/keys [data]} & nums]
                 {::bread/data (assoc data :sum (reduce + nums))})
           handler (-> (bread/app)
@@ -208,7 +208,18 @@
                       (assoc ::bread/data {:sum 0})
                       (bread/handler))]
       (is (= 6 (-> (handler {:uri "/"})
-                   (get-in [::bread/data :sum])))))))
+                   (get-in [::bread/data :sum]))))))
+
+  (testing "futures are valid Effects"
+    (let [external (atom 0)
+          future-effect (future
+                          {::bread/data {:num (swap! external inc)}})
+          handler (-> (bread/app)
+                      (bread/add-effect future-effect)
+                      (assoc ::bread/data {:num 0})
+                      (bread/handler))]
+      (is (= 1 (-> (handler {:uri "/"})
+                   (get-in [::bread/data :num])))))))
 
 (deftest test-add-value-hook
 

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -132,6 +132,7 @@
                [::bread/from-ns ::bread/file]
                (bread/hooks-for req :my/hook)))))))
 
+#_
 (deftest test-add-effect
 
   (testing "it adds to the :hook/effects hook inside app"
@@ -322,6 +323,7 @@
 
 (deftest test-load-handler
 
+  #_
   (testing "it returns a function that loads plugins"
     (let [my-plugin #(bread/add-effect % identity)
           app (bread/app {:plugins [my-plugin]})
@@ -340,6 +342,7 @@
              (bread/config (handler {:url "/"}) :my/config)))))
 
   ;; TODO test effects in isolation
+  #_
   (testing "it returns a function that applies side-effects"
     (let [;; Test side-effects
           state (atom {:num 3 :extra :stuff})

--- a/test/systems/bread/alpha/core_test.clj
+++ b/test/systems/bread/alpha/core_test.clj
@@ -153,6 +153,22 @@
       (is (false? (bread/hook-for? app :hook/effects dec {:precedence 3})))
       (is (false? (bread/hook-for? app :hook/effects identity {:x :y}))))))
 
+(deftest test-add-effect
+
+  (testing "it adds the given Effect to ::effects"
+    (are [effects app] (= effects (::bread/effects app))
+
+         [identity] (-> (bread/app)
+                        (bread/add-effect identity))
+
+         [inc] (-> (bread/app)
+                   (bread/add-effect inc))
+
+         [inc dec identity] (-> (bread/app)
+                                (bread/add-effect inc)
+                                (bread/add-effect dec)
+                                (bread/add-effect identity)))))
+
 (deftest test-add-value-hook
 
   (testing "add-value-hook wraps passed value in (constantly ,,,)"

--- a/tools/systems/bread/alpha/tools/debugger.clj
+++ b/tools/systems/bread/alpha/tools/debugger.clj
@@ -140,6 +140,9 @@
   (fn [app]
     (bread/add-hooks->
       app
-      (:hook/request #(assoc % :request/uuid (uuid)))
-      (:hook/request #(assoc % :request/timestamp (Date.)))
-      (:hook/response #(assoc % :response/timestamp (Date.))))))
+      (:hook/request
+        #(assoc % :request/uuid (uuid) :request/timestamp (Date.))
+        {:precedence 0})
+      (:hook/response
+        #(assoc % :response/timestamp (Date.))
+        {:precedence 100}))))


### PR DESCRIPTION
Up til now I've basically punted on implementing side-effects, focusing instead on concise abstractions for querying and rendering data. The time has come to implement generic Effects!

## Context/Architecture

A generic request lifecycle in a Bread app looks like this:

```clj
(-> (merge req app)
    (hook :hook/request)   ;; filter the initial Ring request data, works like route-specific middleware
    (hook :hook/dispatch)  ;; -> ::resolver
    (hook :hook/resolve)   ;; -> ::queries
    (hook :hook/expand)    ;; -> ::data
    (apply-effects)        ;; -> more ::data
    (hook :hook/render)    ;; -> standard Ring keys: :status, :headers, :body
    (hook :hook/response)) ;; arbitrarily modify the Ring response
```

where `app` starts out as a map with `::hooks`, `::plugins`, and `::config` keys. (This snippet was lifted straight out of the `handler` defn in `core.cljc`; `hook` is a core Bread fn.) Plugins are responsible for loading in their own logic via `add-hook`; almost everything beyond this generic lifecycle is implemented as a plugin (truthfullly, about half-implemented so far 😛).

The idea draws inspiration from Pedestal's interceptors. The key difference is that you can dynamically add callbacks for a given hook by its name, affording arbitrary integration points in completely disparate plugins:

```clj
(defn plugin-a []
  (fn [app]
    (bread/add-hook app :hook/my-val inc)))

(defn plugin-b []
  (fn [app]
    (bread/add-hook app :hook/my-val (partial * 2))))

(-> (bread/load-app (bread/app {:plugins [plugin-a plugin-b]})) ;; loads plugins
    (bread/hook-> :hook/my-val 1))
;; => 4
```

It also draws inspiration from WordPress's `add_filter()`. The difference there is that, whereas in WP `add_filter()` reads from  global state, `hook` and `add-hook` are purely functional: all they do is return a new `app` map. **As of this PR, that's what `add-effect` does too!**

Until now, the `apply-effects` lifecycle phase was implemented as just another hook. This didn't really work because it didn't allow for Effects to queue up other Effects arbitrarily. It was also awkward from an implementation standpoint because it meant the core had to either special-case the `:hook/apply-effects` hook or apply the same invocation logic to all non-Effect hooks. This separates out `apply-effects` into its own thing with its own semantics: basically, as soon as `(::effects app)` is empty, we're done and there are no more side-effects to apply.

## Requirements

* Effects should be totally generic and backed by a protocol. For example if someone wants to do `(bread/add-effect app (chan))`, they can define what it means to treat a channel as an Effect: you might imagine that it waits for a timeout or something, but the point it is it's up to them.
* Functions are valid Effects
  * passed the current app/request when invoked
  * expected to close around any other data they need
* Futures are valid Effects, dereferenced at invocation time
* Vectors are valid Effects
  * the first element is assumed to be a `fn`
  * the remaining elements are passed to the fn via `apply`
* Effects can add other Effects! If an Effect returns a map with a `::systems.bread.alpha.core/effects` key, those replace the old Effects in the app going forward. This allows a generic mechanism for enqueuing more work as the result of a side-effect when you don't know what that result will be ahead of time. For example, say your Effect has to get a list of _n_ entities from an external API and then make _n_ more calls to the API - one for each entity. You could define it all in one big function, but depending on the other work you need to do with the data (deserialization, validation, etc.) it might be more modular/testable to chunk out the follow-up work as separate Effects.
* Effects can filter app `::data` (specifically, the arbitrary map of stuff that gets passed to the renderer, not just via db txs)

## Testing

You should be able to clone the repo and run `clj -M:test` - add the `--watch` flag if you want to poke around the code and run the tests when files change.

The dev sandbox (lovingly named `breadbox`) is kind of a mess right now, but if you want to try spinning it up, you can:

```sh
$ clj -M:dev:cms:repl:tools # I know, I know :P
nREPL server started on port XXXXX on host localhost - nrepl://localhost:XXXXX
```

Once that's going, connect to the reported nREPL port and evaluate the full `dev/breadbox/app.clj` in a buffer. It'll take a few seconds to eval the whole thing. Finally, you can eval the `(mount/start)` form near the bottom and then the sandbox app should be running at http://localhost:1312. The `counter` atom added in this PR should get `mount`ed when the app starts. You should see it get incremented with each request - `add-effect` in action!

## Eventually

In a future PR I'd like to:

* extend the `Effect` protocol for db transactions (as a `deftype` or `defrecord`)
* add a `store/add-txs` convenience fn for adding DB transactions as Effects
* add a `bread/add-transform` fn for adding an Effect that will only transform `::data` (not queue any additional `::effects`) as the result of a side-effect