### PR TITLE
Feature/navigation

### DIFF
--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -243,7 +243,6 @@
                          {:menus [{:key :main-nav
                                    :type :posts
                                    :post/type :post.type/page}
-                                  #_ ;; TODO add support for :location
                                   {:key :footer-nav
                                    :type :location
                                    :location :footer-nav}]

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -21,7 +21,6 @@
     [systems.bread.alpha.plugin.rum :as rum]
     [systems.bread.alpha.plugin.static-backend :as static-be]
     [systems.bread.alpha.post :as post]
-    [systems.bread.alpha.navigation :as navigation]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.resolver :as resolver]
     [systems.bread.alpha.route :as route]
@@ -211,6 +210,26 @@
                    (cms/default-app
                      {:datastore $config
                       :router $router
+                      :navigation
+                      {:menus [{:key :main-nav
+                                :type :posts
+                                :post/type :post.type/page}
+                               {:key :footer-nav
+                                :type :location
+                                :location :footer-nav}]
+                       :global-menus? false
+                       :hooks [[:hook/posts-menu
+                                #(update %2 :my/class str " posts-menu")]
+                               [:hook/posts-menu.page
+                                #(update %2 :my/class str " posts-menu--page")]
+                               [:hook/menu
+                                #(assoc %2 :my/class "nav-menu")]
+                               ;; These don't currently run
+                               ;; because global menus are disabled...
+                               [:hook/menu.location.main-nav
+                                #(update %2 :my/class str " main-nav")]
+                               [:hook/menu.key.main
+                                #(update %2 :my/class str " special")]]}
                       :plugins
                       [(debug/plugin)
                        (rum/plugin)
@@ -238,27 +257,6 @@
                            (fn [_]
                              (throw (ex-info "OH NOEZ"
                                              {:something :bad})))))
-
-                       (navigation/plugin
-                         {:menus [{:key :main-nav
-                                   :type :posts
-                                   :post/type :post.type/page}
-                                  {:key :footer-nav
-                                   :type :location
-                                   :location :footer-nav}]
-                          :global-menus? false
-                          :hooks [[:hook/posts-menu
-                                   #(update %2 :my/class str " posts-menu")]
-                                  [:hook/posts-menu.page
-                                   #(update %2 :my/class str " posts-menu--page")]
-                                  [:hook/menu
-                                   #(assoc %2 :my/class "nav-menu")]
-                                  ;; These don't currently run
-                                  ;; because global menus are disabled...
-                                  [:hook/menu.location.main-nav
-                                   #(update %2 :my/class str " main-nav")]
-                                  [:hook/menu.key.main
-                                   #(update %2 :my/class str " special")]]})
 
                        ;; TODO layouts
                        ;; TODO themes

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -52,12 +52,14 @@
         {:keys [title simple]} (:post/fields post)]
     [:main
      [:h1 title]
-     [:p (:hello simple)]]))
+     [:p (:hello simple)]
+     [:pre (str post)]]))
 
-(defc page [{:keys [post i18n my-menu] :as data}]
+(defc page [{:keys [post i18n menus] :as data}]
   {:query [{:post/fields [:field/key :field/content]}]
    :key :post}
   (let [post (post/compact-fields post)
+        main-nav (:main-nav menus)
         {:keys [title simple flex-content]} (:post/fields post)]
     [:<>
      [:h1 title]
@@ -66,12 +68,14 @@
        (map
          (fn [{:keys [url title]}]
            [:li [:a {:href url} title]])
-         (:items my-menu))]]
+         (:items main-nav))]]
      [:main
       [:h2 (:hello simple)]
       [:p (:body simple)]
       [:p.goodbye (:goodbye simple)]
-      [:p.flex flex-content]]]))
+      [:p.flex flex-content]]
+     [:pre
+      (str post)]]))
 
 (defc static-page [{:keys [post lang]}]
   {:key :post}

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -233,6 +233,7 @@
                              (throw (ex-info "OH NOEZ"
                                              {:something :bad})))))
 
+                       #_
                        (navigation/plugin)
 
                        ;; TODO layouts

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -45,37 +45,54 @@
               :datastore/initial-txns
               data/initial-content})
 
-(defc home [{:keys [post] :as x}]
+(defn main-nav [menu]
+  [:nav
+   [:ul
+    (map
+      (fn [{:keys [url title children]}]
+        [:li
+         [:a {:href url} title]
+         (when (seq children)
+           [:ul
+            (map
+              (fn [{:keys [url title]}]
+                [:li
+                 [:a {:href url} title]])
+              children)])])
+      (:items menu))]])
+
+(defc home [{:keys [post menus] :as x}]
   {:query [:post/slug {:post/fields [:field/key :field/content]}]
    :key :post}
   (let [post (post/compact-fields post)
         {:keys [title simple]} (:post/fields post)]
     [:main
      [:h1 title]
+     (main-nav (:main-nav menus))
      [:p (:hello simple)]
-     [:pre (str post)]]))
+     [:pre (str post)]
+     ;; TODO layouts
+     [:footer
+      (main-nav (:footer-nav menus))]]))
 
 (defc page [{:keys [post i18n menus] :as data}]
   {:query [{:post/fields [:field/key :field/content]}]
    :key :post}
   (let [post (post/compact-fields post)
-        main-nav (:main-nav menus)
         {:keys [title simple flex-content]} (:post/fields post)]
     [:<>
      [:h1 title]
-     [:nav
-      [:ul
-       (map
-         (fn [{:keys [url title]}]
-           [:li [:a {:href url} title]])
-         (:items main-nav))]]
+     (main-nav (:main-nav menus))
      [:main
       [:h2 (:hello simple)]
       [:p (:body simple)]
       [:p.goodbye (:goodbye simple)]
       [:p.flex flex-content]]
      [:pre
-      (str post)]]))
+      (str post)]
+     ;; TODO layouts
+     [:footer
+      (main-nav (:footer-nav menus))]]))
 
 (defc static-page [{:keys [post lang]}]
   {:key :post}

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -132,18 +132,24 @@
      ["/hello/" hello-handler]
      ["/:lang"
       ["/" {:bread/resolver {:resolver/type :resolver.type/page}
-            :bread/component home}]
+            :bread/component home
+            :name :bread.route/home}]
       ["/static/:slug" {:bread/resolver {:resolver/type :resolver.type/static}
                         :bread/component static-page
                         :bread/watch-static {:dir "dev/content"
-                                             :path->req [0 "static" 1]}}]
+                                             :path->req [0 "static" 1]}
+                        :name :bread.route/static}]
       ["/*slugs" {:bread/resolver {:resolver/type :resolver.type/page}
-                  :bread/component page}]]]
+                  :bread/component page
+                  :name :bread.route/page}]]]
     {:conflicts nil}))
 
 (comment
-  (def $res (handler {:uri "/en/qwerty"}))
+  (def $res (handler {:uri "/en/one/two"}))
   (route/params @app (route/match $res))
+  (reitit/match-by-path $router "/en/one/two")
+  (reitit/match-by-name $router :bread.route/page
+                        {:lang :en :slugs "one/two"})
 
   (i18n/t (assoc @app :uri "/en/") :not-found)
   (i18n/t (assoc @app :uri "/fr/") :not-found)

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -21,6 +21,7 @@
     [systems.bread.alpha.plugin.rum :as rum]
     [systems.bread.alpha.plugin.static-backend :as static-be]
     [systems.bread.alpha.post :as post]
+    [systems.bread.alpha.navigation :as navigation]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.resolver :as resolver]
     [systems.bread.alpha.route :as route]
@@ -53,14 +54,19 @@
      [:h1 title]
      [:p (:hello simple)]]))
 
-(defc page [{:keys [post i18n nav] :as data}]
+(defc page [{:keys [post i18n my-menu] :as data}]
   {:query [{:post/fields [:field/key :field/content]}]
    :key :post}
-  (prn nav)
   (let [post (post/compact-fields post)
         {:keys [title simple flex-content]} (:post/fields post)]
     [:<>
      [:h1 title]
+     [:nav
+      [:ul
+       (map
+         (fn [{:keys [url title]}]
+           [:li [:a {:href url} title]])
+         (:items my-menu))]]
      [:main
       [:h2 (:hello simple)]
       [:p (:body simple)]
@@ -206,18 +212,7 @@
                              (throw (ex-info "OH NOEZ"
                                              {:something :bad})))))
 
-                       (fn [app]
-                         (bread/add-hook
-                           app
-                           :hook/resolve
-                           (fn [{::bread/keys [queries] :as req}]
-                             (query/add
-                               req
-                               [:nav
-                                (store/datastore req)
-                                '{:find [?p (pull ?e [:field/key :field/content])]
-                                  :where [[?e :field/lang :en]
-                                          [?p :post/fields ?e]]}]))))
+                       (navigation/plugin)
 
                        ;; TODO layouts
                        ;; TODO themes

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -240,12 +240,26 @@
                                              {:something :bad})))))
 
                        (navigation/plugin
-                         {:hooks {:hook/menu
-                                  #(assoc %2 :my/class "nav-menu")
-                                  :hook/menu.location.main-nav
-                                  #(update %2 :my/class str " main-nav")
-                                  :hook/menu.key.main
-                                  #(update %2 :my/class str " special")}})
+                         {:menus [{:key :main-nav
+                                   :type :posts
+                                   :post/type :post.type/page}
+                                  #_ ;; TODO add support for :location
+                                  {:key :footer-nav
+                                   :type :location
+                                   :location :footer-nav}]
+                          :global-menus? false
+                          :hooks [[:hook/posts-menu
+                                   #(update %2 :my/class str " posts-menu")]
+                                  [:hook/posts-menu.page
+                                   #(update %2 :my/class str " posts-menu--page")]
+                                  [:hook/menu
+                                   #(assoc %2 :my/class "nav-menu")]
+                                  ;; These don't currently run
+                                  ;; because global menus are disabled...
+                                  [:hook/menu.location.main-nav
+                                   #(update %2 :my/class str " main-nav")]
+                                  [:hook/menu.key.main
+                                   #(update %2 :my/class str " special")]]})
 
                        ;; TODO layouts
                        ;; TODO themes

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -233,7 +233,6 @@
                              (throw (ex-info "OH NOEZ"
                                              {:something :bad})))))
 
-                       #_
                        (navigation/plugin)
 
                        ;; TODO layouts

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -241,6 +241,22 @@
 
                        (navigation/plugin)
 
+                       (fn [app]
+                         (bread/add-hooks->
+                           app
+                           (:hook/menu
+                             (fn [_ menu]
+                               (prn 'menu (:key menu))
+                               menu))
+                           (:hook/menu.location.footer-nav
+                             (fn [_ menu]
+                               (prn 'loc (:key menu))
+                               menu))
+                           (:hook/menu.key.footer
+                             (fn [_ menu]
+                               (prn 'key (:key menu))
+                               menu))))
+
                        ;; TODO layouts
                        ;; TODO themes
 

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -46,7 +46,7 @@
               data/initial-content})
 
 (defn main-nav [menu]
-  [:nav
+  [:nav {:class (:my/class menu)}
    [:ul
     (map
       (fn [{:keys [url title children]}]
@@ -239,23 +239,13 @@
                              (throw (ex-info "OH NOEZ"
                                              {:something :bad})))))
 
-                       (navigation/plugin)
-
-                       (fn [app]
-                         (bread/add-hooks->
-                           app
-                           (:hook/menu
-                             (fn [_ menu]
-                               (prn 'menu (:key menu))
-                               menu))
-                           (:hook/menu.location.footer-nav
-                             (fn [_ menu]
-                               (prn 'loc (:key menu))
-                               menu))
-                           (:hook/menu.key.footer
-                             (fn [_ menu]
-                               (prn 'key (:key menu))
-                               menu))))
+                       (navigation/plugin
+                         {:hooks {:hook/menu
+                                  #(assoc %2 :my/class "nav-menu")
+                                  :hook/menu.location.main-nav
+                                  #(update %2 :my/class str " main-nav")
+                                  :hook/menu.key.main
+                                  #(update %2 :my/class str " special")}})
 
                        ;; TODO layouts
                        ;; TODO themes

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -2,7 +2,7 @@
   (:import
     [java.util UUID]))
 
-(def parent-uuid
+(def child-uuid
   #uuid "cd255e79-93c3-447c-ad94-045758de9b31")
 
 (def initial-content
@@ -26,21 +26,9 @@
                     }
           :status :post.status/published}
    #:post{:type :post.type/page
-          :uuid parent-uuid
-          :slug "parent-page"
-          :status :post.status/published
-          :fields #{{:field/key :title
-                     :field/lang :en
-                     :field/content (prn-str "Parent Page")}
-                    {:field/key :title
-                     :field/lang :fr
-                     :field/content (prn-str "La Page Parent")}
-                    }}
-   #:post{:type :post.type/page
-          :uuid (UUID/randomUUID)
+          :uuid child-uuid
           :slug "child-page"
           :status :post.status/published
-          :parent [:post/uuid parent-uuid]
           :fields #{{:field/key :title
                      :field/lang :en
                      :field/content (prn-str "Child Page")}
@@ -67,8 +55,35 @@
           :taxons #{{:taxon/slug "my-cat"
                      :taxon/name "My Cat"
                      :taxon/taxonomy :taxon.taxonomy/category}}}
+   #:post{:type :post.type/page
+          :uuid (UUID/randomUUID)
+          :slug "parent-page"
+          :children [[:post/uuid child-uuid]]
+          :status :post.status/published
+          :fields #{{:field/key :title
+                     :field/lang :en
+                     :field/content (prn-str "Parent Page")}
+                    {:field/key :title
+                     :field/lang :fr
+                     :field/content (prn-str "La Page Parent")}
+                    {:field/key :simple
+                     :field/lang :en
+                     :field/content
+                     (prn-str {:hello "Hello"
+                               :body "Lorem ipsum dolor sit amet"
+                               :goodbye "Goodbye from Parent!"
+                               :img-url "https://via.placeholder.com/300"})}
+                    {:field/key :simple
+                     :field/lang :fr
+                     :field/content
+                     (prn-str {:hello "Bonjour"
+                               :body "Lorem ipsum en francais"
+                               :goodbye "Salut de la page parent"
+                               :img-url "https://via.placeholder.com/300"})}
+                    }}
    #:menu{:locations [:main-nav]
           :key :main
+          ;; TODO use UUIDs to accomplish this :P
           :menu/content (prn-str [{:db/id 52     ;; parent
                                    :children
                                    [{:db/id 55}]} ;; child

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -67,14 +67,14 @@
           :taxons #{{:taxon/slug "my-cat"
                      :taxon/name "My Cat"
                      :taxon/taxonomy :taxon.taxonomy/category}}}
-   #:menu{:location :main-nav
+   #:menu{:locations [:main-nav]
           :key :main
           :menu/content (prn-str [{:post/id 52     ;; parent
                                    :children
                                    [{:post/id 55}]} ;; child
                                   {:post/id 47}    ;; home
                                   ])}
-   #:menu{:location :footer-nav
+   #:menu{:locations [:footer-nav]
           :key :footer
           :menu/content (prn-str [{:post/id 47}
                                   {:post/id 52}

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -69,14 +69,14 @@
                     {:field/key :simple
                      :field/lang :en
                      :field/content
-                     (prn-str {:hello "Hello"
+                     (prn-str {:hello "Greetings!"
                                :body "Lorem ipsum dolor sit amet"
                                :goodbye "Goodbye from Parent!"
                                :img-url "https://via.placeholder.com/300"})}
                     {:field/key :simple
                      :field/lang :fr
                      :field/content
-                     (prn-str {:hello "Bonjour"
+                     (prn-str {:hello "Ca va?"
                                :body "Lorem ipsum en francais"
                                :goodbye "Salut de la page parent"
                                :img-url "https://via.placeholder.com/300"})}
@@ -84,16 +84,16 @@
    #:menu{:locations [:main-nav]
           :key :main
           ;; TODO use UUIDs to accomplish this :P
-          :menu/content (prn-str [{:db/id 52     ;; parent
+          :menu/content (prn-str [{:db/id 59     ;; parent
                                    :children
-                                   [{:db/id 55}]} ;; child
+                                   [{:db/id 52}]} ;; child
                                   {:db/id 47}    ;; home
                                   ])}
    #:menu{:locations [:footer-nav]
           :key :footer
           :menu/content (prn-str [{:db/id 47}
                                   {:db/id 52}
-                                  {:db/id 55}])}
+                                  {:db/id 59}])}
    #:i18n{:lang :en
           :key :not-found
           :string "404 Not Found"}

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -69,9 +69,11 @@
                      :taxon/taxonomy :taxon.taxonomy/category}}}
    #:menu{:location :main-nav
           :key :main
-          :menu/content (prn-str [{:post/id 47}
-                                  {:post/id 52}
-                                  {:post/id 55}])}
+          :menu/content (prn-str [{:post/id 52     ;; parent
+                                   :children
+                                   [{:post/id 55}]} ;; child
+                                  {:post/id 47}    ;; home
+                                  ])}
    #:menu{:location :footer-nav
           :key :footer
           :menu/content (prn-str [{:post/id 47}

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -7,76 +7,76 @@
 
 (def initial-content
   [#:post{:type :post.type/page
-                    :uuid (UUID/randomUUID)
-                    :slug ""
-                    :fields #{{:field/key :title
-                               :field/lang :en
-                               :field/content (prn-str "The Title")}
-                              {:field/key :title
-                               :field/lang :fr
-                               :field/content (prn-str "Le Titre")}
-                              {:field/key :simple
-                               :field/lang :en
-                               :field/content (prn-str {:hello "Hi!"
-                                                        :img-url "https://via.placeholder.com/300"})}
-                              {:field/key :simple
-                               :field/lang :fr
-                               :field/content (prn-str {:hello "Allo!"
-                                                        :img-url "https://via.placeholder.com/300"})}
-                              }
-                    :status :post.status/published}
-             #:post{:type :post.type/page
-                    :uuid parent-uuid
-                    :slug "parent-page"
-                    :status :post.status/published
-                    :fields #{{:field/key :title
-                               :field/lang :en
-                               :field/content (prn-str "Parent Page")}
-                              {:field/key :title
-                               :field/lang :fr
-                               :field/content (prn-str "La Page Parent")}
-                              }}
-             #:post{:type :post.type/page
-                    :uuid (UUID/randomUUID)
-                    :slug "child-page"
-                    :status :post.status/published
-                    :parent [:post/uuid parent-uuid]
-                    :fields #{{:field/key :title
-                               :field/lang :en
-                               :field/content (prn-str "Child Page")}
-                              {:field/key :title
-                               :field/lang :fr
-                               :field/content (prn-str "La Page Enfant")}
-                              {:field/key :simple
-                               :field/lang :en
-                               :field/content
-                               (prn-str {:hello "Hello"
-                                         :body "Lorem ipsum dolor sit amet"
-                                         :goodbye "Bye!"
-                                         :img-url "https://via.placeholder.com/300"})}
-                              {:field/key :simple
-                               :field/lang :fr
-                               :field/content
-                               (prn-str {:hello "Bonjour"
-                                         :body "Lorem ipsum en francais"
-                                         :goodbye "Salut"
-                                         :img-url "https://via.placeholder.com/300"})}
-                              {:field/key :flex-content
-                               :field/lang :en
-                               :field/content (prn-str {:todo "TODO"})}}
-                    :taxons #{{:taxon/slug "my-cat"
-                               :taxon/name "My Cat"
-                               :taxon/taxonomy :taxon.taxonomy/category}}}
-             #:i18n{:lang :en
-                    :key :not-found
-                    :string "404 Not Found"}
-             #:i18n{:lang :fr
-                    :key :not-found
-                    :string "404 Pas Trouvé"}
-             #:i18n{:lang :fr
-                    :key :breadbox
-                    :string "Boite à pain"}
-             #:i18n{:lang :en
-                    :key :breadbox
-                    :string "Breadbox"}
-             ])
+          :uuid (UUID/randomUUID)
+          :slug ""
+          :fields #{{:field/key :title
+                     :field/lang :en
+                     :field/content (prn-str "The Title")}
+                    {:field/key :title
+                     :field/lang :fr
+                     :field/content (prn-str "Le Titre")}
+                    {:field/key :simple
+                     :field/lang :en
+                     :field/content (prn-str {:hello "Hi!"
+                                              :img-url "https://via.placeholder.com/300"})}
+                    {:field/key :simple
+                     :field/lang :fr
+                     :field/content (prn-str {:hello "Allo!"
+                                              :img-url "https://via.placeholder.com/300"})}
+                    }
+          :status :post.status/published}
+   #:post{:type :post.type/page
+          :uuid parent-uuid
+          :slug "parent-page"
+          :status :post.status/published
+          :fields #{{:field/key :title
+                     :field/lang :en
+                     :field/content (prn-str "Parent Page")}
+                    {:field/key :title
+                     :field/lang :fr
+                     :field/content (prn-str "La Page Parent")}
+                    }}
+   #:post{:type :post.type/page
+          :uuid (UUID/randomUUID)
+          :slug "child-page"
+          :status :post.status/published
+          :parent [:post/uuid parent-uuid]
+          :fields #{{:field/key :title
+                     :field/lang :en
+                     :field/content (prn-str "Child Page")}
+                    {:field/key :title
+                     :field/lang :fr
+                     :field/content (prn-str "La Page Enfant")}
+                    {:field/key :simple
+                     :field/lang :en
+                     :field/content
+                     (prn-str {:hello "Hello"
+                               :body "Lorem ipsum dolor sit amet"
+                               :goodbye "Bye!"
+                               :img-url "https://via.placeholder.com/300"})}
+                    {:field/key :simple
+                     :field/lang :fr
+                     :field/content
+                     (prn-str {:hello "Bonjour"
+                               :body "Lorem ipsum en francais"
+                               :goodbye "Salut"
+                               :img-url "https://via.placeholder.com/300"})}
+                    {:field/key :flex-content
+                     :field/lang :en
+                     :field/content (prn-str {:todo "TODO"})}}
+          :taxons #{{:taxon/slug "my-cat"
+                     :taxon/name "My Cat"
+                     :taxon/taxonomy :taxon.taxonomy/category}}}
+   #:i18n{:lang :en
+          :key :not-found
+          :string "404 Not Found"}
+   #:i18n{:lang :fr
+          :key :not-found
+          :string "404 Pas Trouvé"}
+   #:i18n{:lang :fr
+          :key :breadbox
+          :string "Boite à pain"}
+   #:i18n{:lang :en
+          :key :breadbox
+          :string "Breadbox"}
+   ])

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -67,14 +67,16 @@
           :taxons #{{:taxon/slug "my-cat"
                      :taxon/name "My Cat"
                      :taxon/taxonomy :taxon.taxonomy/category}}}
-   #:post{:type :post.type/menu
-          :slug "my-menu"
-          :status :post.status/published
-          :fields #{{:field/key :menu/items
-                     :field/content (prn-str [{:post/id 51}
-                                              {:post/id 43}
-                                              {:post/id 48}])}
-                    }}
+   #:menu{:location :main-nav
+          :key :main
+          :menu/content (prn-str [{:post/id 47}
+                                  {:post/id 52}
+                                  {:post/id 55}])}
+   #:menu{:location :footer-nav
+          :key :footer
+          :menu/content (prn-str [{:post/id 47}
+                                  {:post/id 52}
+                                  {:post/id 55}])}
    #:i18n{:lang :en
           :key :not-found
           :string "404 Not Found"}

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -69,16 +69,16 @@
                      :taxon/taxonomy :taxon.taxonomy/category}}}
    #:menu{:locations [:main-nav]
           :key :main
-          :menu/content (prn-str [{:post/id 52     ;; parent
+          :menu/content (prn-str [{:db/id 52     ;; parent
                                    :children
-                                   [{:post/id 55}]} ;; child
-                                  {:post/id 47}    ;; home
+                                   [{:db/id 55}]} ;; child
+                                  {:db/id 47}    ;; home
                                   ])}
    #:menu{:locations [:footer-nav]
           :key :footer
-          :menu/content (prn-str [{:post/id 47}
-                                  {:post/id 52}
-                                  {:post/id 55}])}
+          :menu/content (prn-str [{:db/id 47}
+                                  {:db/id 52}
+                                  {:db/id 55}])}
    #:i18n{:lang :en
           :key :not-found
           :string "404 Not Found"}

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -67,6 +67,14 @@
           :taxons #{{:taxon/slug "my-cat"
                      :taxon/name "My Cat"
                      :taxon/taxonomy :taxon.taxonomy/category}}}
+   #:post{:type :post.type/menu
+          :slug "my-menu"
+          :status :post.status/published
+          :fields #{{:field/key :menu/items
+                     :field/content (prn-str [{:post/id 51}
+                                              {:post/id 43}
+                                              {:post/id 48}])}
+                    }}
    #:i18n{:lang :en
           :key :not-found
           :string "404 Not Found"}

--- a/plugins/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/systems/bread/alpha/plugin/reitit.cljc
@@ -1,6 +1,7 @@
 (ns systems.bread.alpha.plugin.reitit
   (:require
     [clojure.core.protocols :refer [Datafiable datafy]]
+    [clojure.string :as string]
     [reitit.core :as reitit]
     [systems.bread.alpha.core :as bread :refer [Router]]
     [systems.bread.alpha.i18n :as i18n]
@@ -24,6 +25,12 @@
                          (let [{:keys [ext] :or {ext ".md"}} config]
                            (assoc config :ext ext))))})
       (reitit/compiled-routes router)))
+  (bread/path [router route-name params]
+    ;; TODO figure out a non-terrible way to do this
+    (as-> router $
+      (reitit/match-by-name $ route-name params)
+      (:path $)
+      (string/replace $ #"%2F" "/")))
   ;; If the matched result is a handler (fn), set it as the resolver directly.
   ;; This lets users opt in or out of Bread's routing on a per-route basis.
   (bread/dispatch [router req]

--- a/src/systems/bread/alpha/cms.cljc
+++ b/src/systems/bread/alpha/cms.cljc
@@ -3,6 +3,7 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.datastore :as store]
     [systems.bread.alpha.i18n :as i18n]
+    [systems.bread.alpha.navigation :as nav]
     [systems.bread.alpha.plugin.reitit]
     [systems.bread.alpha.plugin.rum :as rum]
     [systems.bread.alpha.query :as query]
@@ -10,11 +11,12 @@
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.component :as component]))
 
-(defn defaults [{:keys [datastore router plugins]}]
+(defn defaults [{:keys [datastore router plugins navigation]}]
   (concat
     [(store/plugin datastore)
      (route/plugin router)
      (i18n/plugin)
+     (nav/plugin navigation)
      (resolver/plugin)
      (query/plugin)
      (component/plugin)]

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -56,11 +56,13 @@
 
 (defprotocol Router
   :extend-via-metadata true
+  (path [this route-name params])
   (dispatch [this req])
   (routes [this])
   (match [this req])
   (params [this match])
   (resolver [this match])
+  ;; TODO redesign component matching
   (component [this match])
   (not-found-component [this match]))
 

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -66,11 +66,15 @@
       (query/add [:lang (fn [_]
                           (lang app))])))
 
+(defn url [req url _post]
+  (str "/" (name (lang req)) url))
+
 (defn plugin
   ([]
    (plugin {}))
   ([opts]
-   (let [fallback (:i18n/fallback opts :en)]
-     (fn [app]
-       (bread/add-hook (bread/set-config app :i18n/fallback-lang fallback)
-         :hook/resolve add-i18n-queries)))))
+   (fn [app]
+     (bread/add-hooks->
+       (bread/set-config app :i18n/fallback-lang (:i18n/fallback opts :en))
+       (:hook/post-url url)
+       (:hook/resolve add-i18n-queries)))))

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -76,7 +76,7 @@
    (fn [app]
      (bread/add-hooks->
        (bread/set-config app
-                         :i18n/lang-param (:i18n/lang-param opts :lang)
-                         :i18n/fallback-lang (:i18n/fallback opts :en))
+                         :i18n/lang-param (:lang-param opts :lang)
+                         :i18n/fallback-lang (:fallback-lang opts :en))
        (:hook/path-params path-params)
        (:hook/resolve add-i18n-queries)))))

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -66,8 +66,8 @@
       (query/add [:lang (fn [_]
                           (lang app))])))
 
-(defn url [req url _post]
-  (str "/" (name (lang req)) url))
+(defn path-params [req params _]
+  (assoc params (bread/config req :i18n/lang-param) (lang req)))
 
 (defn plugin
   ([]

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -75,6 +75,8 @@
   ([opts]
    (fn [app]
      (bread/add-hooks->
-       (bread/set-config app :i18n/fallback-lang (:i18n/fallback opts :en))
-       (:hook/post-url url)
+       (bread/set-config app
+                         :i18n/lang-param (:i18n/lang-param opts :lang)
+                         :i18n/fallback-lang (:i18n/fallback opts :en))
+       (:hook/path-params path-params)
        (:hook/resolve add-i18n-queries)))))

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -3,8 +3,9 @@
     [clojure.string :as str]
     [clojure.walk :as walk]
     [systems.bread.alpha.core :as bread]
+    [systems.bread.alpha.datastore :as store]
     [systems.bread.alpha.route :as route]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.query :as query]))
 
 ;; TODO make this fn pluggable
 (defn supported-langs
@@ -59,12 +60,11 @@
   (k (strings app)))
 
 (defn add-i18n-queries [app]
-  ;; TODO query/add
   (-> app
-      (update ::bread/queries conj [:i18n (fn [_]
-                                            (strings app))])
-      (update ::bread/queries conj [:lang (fn [_]
-                                            (lang app))])))
+      (query/add [:i18n (fn [_]
+                          (strings app))])
+      (query/add [:lang (fn [_]
+                          (lang app))])))
 
 (defn plugin
   ([]

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -7,37 +7,10 @@
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.datastore :as store]))
 
-(comment
-
-  $db
-
-  (store/q $db '{:find [(pull ?e [:post/slug {:post/fields [:field/key :field/content]} ])]
-                 :where [[?e :post/type :post.type/menu]
-                         [?e :post/slug "my-menu"]]})
-
-  (store/q $db '{:find [?p (pull ?e [:field/content ])]
-                 :where [[?e :field/lang :en]
-                         [?e :field/key :title]
-                         [?p :post/fields ?e]
-                         (or [51 :post/fields ?e]
-                             [43 :post/fields ?e])]})
-  ;;
-  )
-
-(defn menu-query
-  "Compute the Datalog query for the menu with the given slug"
-  [req slug]
-  (let [query {:find '[(pull ?e [:post/slug
-                                 {:post/fields [:field/key
-                                                :field/content]}]) .]
-               :where [['?e :post/type :post.type/menu]
-                       ['?e :post/slug (name slug)]]}]
-    (bread/hook-> req :hook/menu-query query)))
-
 (defn- post-items-query [req menu]
   (let [lang (i18n/lang req)
         ids-clause (->> menu
-                        :menu/items
+                        :menu/content
                         (map :post/id)
                         (filter some?)
                         (map (fn [id]
@@ -61,24 +34,40 @@
         (store/q (store/datastore req)
                  (post-items-query req menu))))
 
-(defn menu [req slug]
-  (let [{fields :post/fields}
-        (store/q (store/datastore req) (menu-query req slug))
-        ;; Query for post fields
-        items
-        (expand-post-ids req (->> fields
-                                  (map (fn [{k :field/key
-                                             content :field/content}]
-                                         [k (edn/read-string content)]))
-                                  (into {})))]
-    {:items items
-     :slug slug}))
+(defn global-menus [req]
+  (into {}
+        (map (fn [results]
+               (let [{:menu/keys [key location] :as result} (first results)
+                     menu (update result :menu/content edn/read-string)]
+                 [location {:key key
+                  :location location
+                  :items (expand-post-ids req menu)}]))
+             (store/q
+               (store/datastore req)
+               '{:find [(pull ?e [:menu/location
+                                  :menu/key
+                                  :menu/content])]
+                 :where [[?e :menu/location _]]}))))
 
-(defn- adder [menu-key]
-  (fn [req]
-    (query/add req [menu-key (fn [data]
-                               (menu req menu-key))])))
+(comment
+  (map
+    (fn [rows]
+      (let [menu (update (first rows) :menu/content edn/read-string)]
+        (expand-post-ids $req menu)))
+    (store/q (store/datastore $req)
+     '{:find [(pull ?e [:menu/location :menu/key :menu/content])]
+       :where [[?e :menu/location _]]}))
+
+  (global-menus $req)
+
+  ;;
+  )
+
+
+(defn query-menus [req]
+  (query/add req [:menus (fn [_]
+                           (global-menus req))]))
 
 (defn plugin []
   (fn [app]
-    (bread/add-hook app :hook/resolve (adder :my-menu))))
+    (bread/add-hook app :hook/resolve query-menus)))

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -52,9 +52,10 @@
 (defn- format-menu [req {k :menu/key loc :menu/locations :as menu}]
   {:key k
    :locations loc
-   :items (as-> menu $
-            (update $ :menu/content edn/read-string)
-            (expand-post-ids req $))})
+   :items (expand-post-ids req menu)})
+
+(defn- parse-content [menu]
+  (update menu :menu/content edn/read-string))
 
 (defn- by-location [menus]
   (reduce (fn [by-loc {locs :locations :as menu}]
@@ -68,8 +69,11 @@
                             :menu/key
                             :menu/content])]
            :where [[?e :menu/locations _]]})
-       (map (comp (partial format-menu req) first))
+       (map (comp (partial format-menu parse-content req) first))
        by-location))
+
+(comment
+  (format-menu $req {:menu/content [{:post/id 47}]}))
 
 (defn query-menus [req]
   (query/add req [:menus (fn [_]

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -9,7 +9,7 @@
 
 (defn- collect-post-ids [tree]
   (reduce (fn [ids node]
-            (apply conj ids (:post/id node)
+            (apply conj ids (:db/id node)
                    (collect-post-ids (:children node))))
           #{}
           tree))
@@ -32,7 +32,7 @@
              ids-clause]}))
 
 (defn- walk-items [by-id items]
-  (mapv (fn [{id :post/id subtree :children}]
+  (mapv (fn [{id :db/id subtree :children}]
           (assoc (by-id id) :children (walk-items by-id subtree)))
         items))
 
@@ -69,13 +69,16 @@
                             :menu/key
                             :menu/content])]
            :where [[?e :menu/locations _]]})
-       (map (comp (partial format-menu parse-content req) first))
+       (map (comp (partial format-menu req) parse-content first))
        by-location))
 
 (comment
-  (format-menu $req {:menu/content [{:post/id 47}]}))
+  (global-menus $req)
+  (format-menu $req {:menu/content [{:db/id 47}]}))
 
 (defn query-menus [req]
+  #_
+  (def $req req)
   (query/add req [:menus (fn [_]
                            (global-menus req))]))
 

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -1,0 +1,84 @@
+(ns systems.bread.alpha.navigation
+  (:require
+    [clojure.edn :as edn]
+    [systems.bread.alpha.core :as bread]
+    [systems.bread.alpha.i18n :as i18n]
+    [systems.bread.alpha.post :as post]
+    [systems.bread.alpha.query :as query]
+    [systems.bread.alpha.datastore :as store]))
+
+(comment
+
+  $db
+
+  (store/q $db '{:find [(pull ?e [:post/slug {:post/fields [:field/key :field/content]} ])]
+                 :where [[?e :post/type :post.type/menu]
+                         [?e :post/slug "my-menu"]]})
+
+  (store/q $db '{:find [?p (pull ?e [:field/content ])]
+                 :where [[?e :field/lang :en]
+                         [?e :field/key :title]
+                         [?p :post/fields ?e]
+                         (or [51 :post/fields ?e]
+                             [43 :post/fields ?e])]})
+  ;;
+  )
+
+(defn menu-query
+  "Compute the Datalog query for the menu with the given slug"
+  [req slug]
+  (let [query {:find '[(pull ?e [:post/slug
+                                 {:post/fields [:field/key
+                                                :field/content]}]) .]
+               :where [['?e :post/type :post.type/menu]
+                       ['?e :post/slug (name slug)]]}]
+    (bread/hook-> req :hook/menu-query query)))
+
+(defn- post-items-query [req menu]
+  (let [lang (i18n/lang req)
+        ids-clause (->> menu
+                        :menu/items
+                        (map :post/id)
+                        (filter some?)
+                        (map (fn [id]
+                               [id :post/fields '?e]))
+                        (apply list 'or))]
+    {:find '[(pull ?p [:db/id :post/slug :post/status
+                       {:post/parent ...}])
+             (pull ?e [:field/content])]
+     :where [['?e :field/lang lang]
+             ['?e :field/key :title]
+             ['?p :post/fields '?e]
+             ids-clause]}))
+
+(defn expand-post-ids [req menu]
+  (mapv (fn [[post {title :field/content}]]
+          (bread/hook->
+            req :hook/post-menu-item
+            {:post post
+             :url (post/url req post)
+             :title (edn/read-string title)}))
+        (store/q (store/datastore req)
+                 (post-items-query req menu))))
+
+(defn menu [req slug]
+  (let [{fields :post/fields}
+        (store/q (store/datastore req) (menu-query req slug))
+        ;; Query for post fields
+        items
+        (expand-post-ids req (->> fields
+                                  (map (fn [{k :field/key
+                                             content :field/content}]
+                                         [k (edn/read-string content)]))
+                                  (into {})))]
+    {:items items
+     :slug slug}))
+
+(defn- adder [menu-key]
+  (fn [req]
+    (query/add req [menu-key (fn [data]
+                               (menu req menu-key))])))
+
+(defn plugin []
+  (fn [app]
+    (bread/add-hook app :hook/resolve (adder :my-menu))))

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -69,14 +69,16 @@
           {} menus))
 
 (defn global-menus [req]
-  (->> (store/q
-         (store/datastore req)
-         '{:find [(pull ?e [:menu/locations
-                            :menu/key
-                            :menu/content])]
-           :where [[?e :menu/locations _]]})
-       (map (comp (partial format-menu req) parse-content first))
-       by-location))
+  (let [query
+        (bread/hook->> req :hook/global-menu-query
+                       '{:find [(pull ?e [:menu/locations
+                                          :menu/key
+                                          :menu/content])]
+                         :where [[?e :menu/locations _]]})]
+    (->> query
+         (store/q (store/datastore req))
+         (map (comp (partial format-menu req) parse-content first))
+         by-location)))
 
 (defn posts-menu
   ([req]

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -102,20 +102,11 @@
      {:items items})))
 
 (comment
-  (posts-menu $req)
-  (invert-tree (posts-menu $req))
-  (invert-tree $tree)
-
-  (store/q
-    (store/datastore $req)
-    '{:find [?e ?slug]
-      :where [[?e :post/type :post.type/page]
-              [?e :post/slug ?slug]]})
-
-  (:main-nav (global-menus $req))
   (format-menu $req {:menu/content [{:db/id 47}
                                     {:db/id 59
-                                     :children [{:db/id 52}]}]}))
+                                     :children [{:db/id 52}]}]})
+  (posts-menu $req)
+  (:main-nav (global-menus $req)))
 
 (defn query-menus [req]
   (def $req req)

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -130,6 +130,12 @@
   (query/add req [:menus (fn [_]
                            (global-menus req))]))
 
-(defn plugin []
-  (fn [app]
-    (bread/add-hook app :hook/resolve query-menus)))
+(defn plugin
+  ([]
+   (plugin {}))
+  ([opts]
+   (let [hooks (merge (:hooks opts) {:hook/resolve query-menus})]
+     (fn [app]
+       (reduce (fn [app [hook callback]]
+                 (bread/add-hook app hook callback))
+               app hooks)))))

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -9,16 +9,6 @@
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.datastore :as store]))
 
-(defn url
-  "Compute the URL for the given post"
-  [req post]
-  (let [url (loop [{:post/keys [slug parent] :as post} post
-                   slugs ()]
-              (if post
-                (recur parent (cons slug slugs))
-                (str "/" (string/join "/" slugs))))]
-    (bread/hook->> req :hook/post-url url post)))
-
 (defn- syms
   ([prefix]
    (syms prefix 0))

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -59,9 +59,9 @@
                             [(list
                                'not-join
                                [descendant-sym]
-                               [descendant-sym :post/parent '?root-ancestor])]))]
+                               ['?root-ancestor :post/children descendant-sym])]))]
               (recur
-                (concat query where [[descendant-sym :post/parent parent-sym]])
+                (concat query where [[parent-sym :post/children descendant-sym]])
                 [inputs (butlast path)]
                 parent-sym ;; the new descendant-sym
                 parent-syms
@@ -70,7 +70,8 @@
 (comment
   (path->constraints ["grandparent" "parent" "child"])
   (path->constraints ["parent" "child"])
-  (path->constraints ["parent" "child"] )
+
+  ;;
   )
 
 (defn- ancestralize [query ancestry]

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -9,6 +9,16 @@
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.datastore :as store]))
 
+(defn url
+  "Compute the URL for the given post"
+  [req post]
+  (let [url (loop [{:post/keys [slug parent] :as post} post
+                   slugs ()]
+              (if post
+                (recur parent (cons slug slugs))
+                (str "/" (string/join "/" slugs))))]
+    (bread/hook->> req :hook/post-url url post)))
+
 (defn- syms
   ([prefix]
    (syms prefix 0))

--- a/src/systems/bread/alpha/query.cljc
+++ b/src/systems/bread/alpha/query.cljc
@@ -38,7 +38,7 @@
   [req query]
   (update req ::bread/queries
           (fn [queries]
-            (vec (conj queries query)))))
+            (vec (conj (vec queries) query)))))
 
 (defn plugin []
   (fn [app]

--- a/src/systems/bread/alpha/query.cljc
+++ b/src/systems/bread/alpha/query.cljc
@@ -33,6 +33,13 @@
          (expand-not-found resolver)
          (assoc req ::bread/data))))
 
+(defn add
+  "Add query to the vector of queries to be run."
+  [req query]
+  (update req ::bread/queries
+          (fn [queries]
+            (vec (conj queries query)))))
+
 (defn plugin []
   (fn [app]
     (bread/add-hook app :hook/expand expand)))

--- a/src/systems/bread/alpha/resolver.cljc
+++ b/src/systems/bread/alpha/resolver.cljc
@@ -60,7 +60,7 @@
                           (get-in req [::bread/resolver :resolver/type])))
 
 (defn resolve-queries [req]
-  (update req ::bread/queries concat (resolve-query req)))
+  (update req ::bread/queries (comp vec concat) (resolve-query req)))
 
 (defn plugin []
   (fn [app]

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -164,11 +164,12 @@
     :db/unique :db.unique/identity
     :db/cardinality :db.cardinality/one
     :migration/key :bread.migration/initial}
-   {:db/ident :menu/location
-    :db/doc "Globally unique menu location."
+   ;; TODO rename to context?
+   {:db/ident :menu/locations
+    :db/doc "Locations this menu is being used for."
     :db/valueType :db.type/keyword
     :db/unique :db.unique/value
-    :db/cardinality :db.cardinality/one
+    :db/cardinality :db.cardinality/many
     :migration/key :bread.migration/initial}
    {:db/ident :menu/key
     :db/doc "Globally unique menu name."

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -39,10 +39,10 @@
     :db/valueType :db.type/ref
     :db/cardinality :db.cardinality/many
     :migration/key :bread.migration/initial}
-   {:db/ident :post/parent
-    :db/doc "Entity ID of the parent post, if any"
+   {:db/ident :post/children
+    :db/doc "Entity IDs of child posts, if any"
     :db/valueType :db.type/ref
-    :db/cardinality :db.cardinality/one
+    :db/cardinality :db.cardinality/many
     :migration/key :bread.migration/initial}
    {:db/ident :post/status
     :db/doc "Post status, i.e. whether it is published, in review, drafting, etc."

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -157,6 +157,31 @@
     :db/cardinality :db.cardinality/one
     :migration/key :bread.migration/initial}
 
+   ;; Menus
+   {:db/ident :menu/uuid
+    :db/doc "Universally unique identifier for the menu. Distinct from the Datahike entity ID."
+    :db/valueType :db.type/uuid
+    :db/unique :db.unique/identity
+    :db/cardinality :db.cardinality/one
+    :migration/key :bread.migration/initial}
+   {:db/ident :menu/location
+    :db/doc "Globally unique menu location."
+    :db/valueType :db.type/keyword
+    :db/unique :db.unique/value
+    :db/cardinality :db.cardinality/one
+    :migration/key :bread.migration/initial}
+   {:db/ident :menu/key
+    :db/doc "Globally unique menu name."
+    :db/valueType :db.type/keyword
+    :db/unique :db.unique/value
+    :db/cardinality :db.cardinality/one
+    :migration/key :bread.migration/initial}
+   {:db/ident :menu/content
+    :db/doc "EDN-serialized menu tree."
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :migration/key :bread.migration/initial}
+
    ;; Comments
    {:db/ident :comment/uuid
     :db/doc "Universally unique identifier for the comment. Distinct from the Datahike entity ID."


### PR DESCRIPTION
Presents a core design solution for #13.

Implements the Navigation API (`systems.bread.alpha.navigation` ns), along with some major changes to:

* Routing: this PR introduces the `route/path` helper, backed by the (new) `bread/path` function from the `Router` protocol.
* Post ancestry: instead of `:post/parent` (many->one) in the schema we now use `:post/children` (one->many). This makes recursively querying for posts much easier.
* `cms/defaults`: this now includes the `navigation/plugin`, with a global config option keyed by `:navigation`

Other changes:

* Bugfix: always make sure `::bread/queries` is a vector
* `query/add` helper for easily adding to `::bread/queries`