### PR TITLE
tools.build script

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,6 +1,7 @@
 (ns build
   (:require
-    [clojure.tools.build.api :as b]))
+    [clojure.tools.build.api :as b]
+    [deps-deploy.deps-deploy :as dd]))
 
 (def lib 'systems.bread/bread-core)
 (def version (format "0.5.%s" (b/git-count-revs nil)))
@@ -21,3 +22,8 @@
                :target-dir class-dir})
   (b/jar {:class-dir class-dir
           :jar-file jar-file}))
+
+(defn deploy [_]
+  (dd/deploy {:installer :remote
+              :artifact jar-file
+              :pom-file (b/pom-path {:lib lib :class-dir class-dir})}))

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,23 @@
+(ns build
+  (:require
+    [clojure.tools.build.api :as b]))
+
+(def lib 'systems.bread/bread-core)
+(def version (format "0.5.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))

--- a/deps.edn
+++ b/deps.edn
@@ -58,5 +58,6 @@
            {:main-opts ["-m" "kaocha.runner"]}
 
            :build
-           {:deps {io.github.clojure/tools.build {:git/tag "v0.8.1" :git/sha "7d40500"}}
+           {:deps {io.github.clojure/tools.build {:git/tag "v0.8.1" :git/sha "7d40500"}
+                   slipset/deps-deploy {:mvn/version "0.2.0"}}
             :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -55,4 +55,8 @@
            {:extra-deps {bidi/bidi {:mvn/version "2.1.6"}}}
 
            :test
-           {:main-opts ["-m" "kaocha.runner"]}}}
+           {:main-opts ["-m" "kaocha.runner"]}
+
+           :build
+           {:deps {io.github.clojure/tools.build {:git/tag "v0.8.1" :git/sha "7d40500"}}
+            :ns-default build}}}


### PR DESCRIPTION
Use [tools.build](https://clojure.org/guides/tools_build) and [deps-deploy](https://github.com/slipset/deps-deploy) to build and deploy to Clojars. Referenced [this tutorial](https://kozieiev.com/blog/creating-and-publishing-clojure-libraries/).