### PR TITLE
Postgres support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -43,11 +43,12 @@
 
            :cms
            {:extra-paths ["plugins" "resources"]
-            :extra-deps {http-kit/http-kit {:mvn/version "2.3.0"}
-                         metosin/reitit    {:mvn/version "0.5.12"}
-                         mount/mount       {:mvn/version "0.1.16"}
-                         ring/ring         {:mvn/version "1.7.0"}
-                         rum/rum           {:mvn/version "0.12.6"}}}
+            :extra-deps {http-kit/http-kit           {:mvn/version "2.3.0"}
+                         io.replikativ/datahike-jdbc {:mvn/version "0.1.2-SNAPSHOT"}
+                         metosin/reitit              {:mvn/version "0.5.12"}
+                         mount/mount                 {:mvn/version "0.1.16"}
+                         ring/ring                   {:mvn/version "1.7.0"}
+                         rum/rum                     {:mvn/version "0.12.6"}}}
 
            ;; Extra deps for testing supported libraries not shipped with the
            ;; CMS build directly.

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -42,7 +42,7 @@
 (def $config {:datastore/type :datahike
               :store {:backend :jdbc
                       :dbtype "postgresql"
-                      :user "tamayo"
+                      :user "breadbox"
                       :dbname "breadbox"
                       :password "breadbox"
                       :id "breadbox-db"}
@@ -200,11 +200,21 @@
 
 (defstate db
   :start (when (:reinstall-db? env)
-           (prn "REINSTALLING DATABASE:" (:datastore/initial-txns $config))
-           (store/install! $config))
+           (println "REINSTALLING DATABASE.")
+           (try
+             (store/install! $config {:force? true})
+             (catch clojure.lang.ExceptionInfo e
+               (println (format "Error reinstalling database: %s"
+                                (ex-message e)))
+               (prn (ex-data e)))))
   :stop (when (:reinstall-db? env)
-          (prn "DELETING DEV DATABASE.")
-          (store/delete-database! $config)))
+          (println "DELETING DEV DATABASE.")
+          (try
+            (store/delete-database! $config)
+            (catch clojure.lang.ExceptionInfo e
+              (println (format "Error deleting database on stop: %s"
+                               (ex-message e)))
+              (prn (ex-data e))))))
 
 ;; TODO reload app automatically when src changes
 ;; NOTE: I think the simplest thing is to put handler in a defstate,

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -8,6 +8,7 @@
     [clojure.edn :as edn]
     [clojure.string :as string]
     [config.core :as config]
+    [datahike-jdbc.core]
     [flow-storm.api :as flow]
     [kaocha.repl :as k]
     [systems.bread.alpha.cms :as cms]
@@ -39,7 +40,11 @@
 (defonce app (atom nil))
 
 (def $config {:datastore/type :datahike
-              :store {:backend :mem
+              :store {:backend :jdbc
+                      :dbtype "postgresql"
+                      :user "tamayo"
+                      :dbname "breadbox"
+                      :password "breadbox"
                       :id "breadbox-db"}
               :datastore/initial-txns
               data/initial-content})

--- a/dev/config.edn
+++ b/dev/config.edn
@@ -2,4 +2,10 @@
  :debug-port 1315
  ;; Reinstall dev database on restart.
  :reinstall-db? true
+ :datahike {:backend :jdbc
+            :dbtype "postgresql"
+            :user "breadbox"
+            :dbname "breadbox"
+            :password "breadbox"
+            :id "breadbox-db"}
  :connect-flowstorm? false}

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -35,6 +35,7 @@
 
 (defprotocol Effect
   "Protocol for encapsulating side-effects"
+  :extend-via-metadata true
   (effect! [this req]))
 
 (extend-protocol Effect

--- a/src/systems/bread/alpha/datastore.cljc
+++ b/src/systems/bread/alpha/datastore.cljc
@@ -5,9 +5,9 @@
     [systems.bread.alpha.core :as bread]))
 
 (defmulti connect! :datastore/type)
-(defmulti create-database! (fn [config _opts]
+(defmulti create-database! (fn [config & _]
                              (:datastore/type config)))
-(defmulti install! (fn [config _opts]
+(defmulti install! (fn [config & _]
                      (:datastore/type config)))
 (defmulti installed? :datastore/type)
 (defmulti delete-database! :datastore/type)

--- a/src/systems/bread/alpha/datastore/datahike.clj
+++ b/src/systems/bread/alpha/datastore/datahike.clj
@@ -243,7 +243,7 @@
                        :message   (.getMessage e)
                        :config    config})))))
 
-(defmethod store/create-database! :datahike [config {:keys [force?]}]
+(defmethod store/create-database! :datahike [config & [{:keys [force?]}]]
   (try
     (d/create-database config)
     (catch clojure.lang.ExceptionInfo e
@@ -252,7 +252,7 @@
           (d/delete-database config)
           (d/create-database config))))))
 
-(defmethod store/install! :datahike [config {:keys [force?]}]
+(defmethod store/install! :datahike [config & {:keys [force?]}]
   (store/create-database! config {:force? force?})
   (d/transact (store/connect! config) schema/initial))
 

--- a/src/systems/bread/alpha/datastore/datahike.clj
+++ b/src/systems/bread/alpha/datastore/datahike.clj
@@ -239,14 +239,21 @@
       (throw (ex-info (str "Exception connecting to datahike: "
                            (.getMessage e))
                       {:exception e
+                       :type      :connection-error
                        :message   (.getMessage e)
                        :config    config})))))
 
-(defmethod store/create-database! :datahike [config]
-  (d/create-database config))
+(defmethod store/create-database! :datahike [config {:keys [force?]}]
+  (try
+    (d/create-database config)
+    (catch clojure.lang.ExceptionInfo e
+      (let [exists? (= :db-already-exists (:type (ex-data e)))]
+        (when (and force? exists?)
+          (d/delete-database config)
+          (d/create-database config))))))
 
-(defmethod store/install! :datahike [config]
-  (d/create-database config)
+(defmethod store/install! :datahike [config {:keys [force?]}]
+  (store/create-database! config {:force? force?})
   (d/transact (store/connect! config) schema/initial))
 
 (defmethod store/delete-database! :datahike [config]


### PR DESCRIPTION
Datahike supports JDBC (and therefore Postgres) transparently via [datahike-jdbc](https://github.com/replikativ/datahike-jdbc). This just adds that library as a dependency in the `cms` alias, and smooths over a few rough edges to make connecting to persistent databases generally better.