### PR TITLE
Taxons

### DIFF
--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -64,15 +64,15 @@
 (declare main-nav)
 
 (defc main-layout
-  [{:keys [content i18n menus]}]
-  {}
-  (prn i18n menus)
-  [:html {:lang "en"}
+  [{:keys [main-content i18n menus lang]}]
+  {:content-path [:main-content]}
+  [:html {:lang lang}
    [:head
-    [:title "Bread Site"]]
+    [:title {:breadbox i18n}]]
    [:body
-    (main-nav (:main-nav menus))
-    content
+    [:header
+     (main-nav (:main-nav menus))]
+    [:main main-content]
     [:footer
      (main-nav (:footer-nav menus))]]])
 
@@ -93,18 +93,15 @@
       (:items menu))]])
 
 (defc home [{:keys [post menus] :as x}]
-  {:query [:post/slug {:post/fields [:field/key :field/content]}]
+  {:extends main-layout
+   :query [:post/slug {:post/fields [:field/key :field/content]}]
    :key :post}
   (let [post (post/compact-fields post)
         {:keys [title simple]} (:post/fields post)]
-    [:main
+    [:<>
      [:h1 title]
-     (main-nav (:main-nav menus))
      [:p (:hello simple)]
-     [:pre (str post)]
-     ;; TODO layouts
-     [:footer
-      (main-nav (:footer-nav menus))]]))
+     [:img {:src (:img-url simple)}]]))
 
 (defc category-page [{:keys [taxon i18n menus] :as data}]
   {:extends main-layout
@@ -117,32 +114,24 @@
     [:<>
      [:h1 (:title fields)]
      [:div [:code slug]]
-     (main-nav (:main-nav menus))
-     [:main
-      (map
-        (fn [{:post/keys [slug fields]}]
-          [:article
-           [:h2 (:title fields)]])
-        posts)]]))
+     (map
+       (fn [{:post/keys [slug fields]}]
+         [:article
+          [:h2 (:title fields)]])
+       posts)]))
 
 (defc page [{:keys [post i18n menus] :as data}]
-  {:query [{:post/fields [:field/key :field/content]}]
+  {:extends main-layout
+   :query [{:post/fields [:field/key :field/content]}]
    :key :post}
   (let [post (post/compact-fields post)
         {:keys [title simple flex-content]} (:post/fields post)]
     [:<>
      [:h1 title]
-     (main-nav (:main-nav menus))
-     [:main
-      [:h2 (:hello simple)]
-      [:p (:body simple)]
-      [:p.goodbye (:goodbye simple)]
-      [:p.flex flex-content]]
-     [:pre
-      (str post)]
-     ;; TODO layouts
-     [:footer
-      (main-nav (:footer-nav menus))]]))
+     [:h2 (:hello simple)]
+     [:p (:body simple)]
+     [:p.goodbye (:goodbye simple)]
+     [:p.flex flex-content]]))
 
 (defc static-page [{:keys [post lang]}]
   {:key :post}

--- a/dev/breadbox/data.clj
+++ b/dev/breadbox/data.clj
@@ -53,10 +53,8 @@
       {:field/key :flex-content
        :field/lang :en
        :field/content (prn-str {:todo "TODO"})}}
-    ;; TODO use unique refs for this
     :post/taxons
-    #{{:taxon/slug "my-cat"
-       :taxon/taxonomy :taxon.taxonomy/category}}}
+    ["taxon.my-cat"]}
    {:db/id "page.sister"
     :post/type :post.type/page
     :post/slug "sister-page"
@@ -87,8 +85,7 @@
        :field/lang :en
        :field/content (prn-str {:todo "TODO"})}}
     :post/taxons
-    #{{:taxon/slug "my-cat"
-       :taxon/taxonomy :taxon.taxonomy/category}}}
+    ["taxon.my-cat"]}
    {:db/id "page.parent"
     :post/type :post.type/page
     :post/slug "parent-page"
@@ -115,6 +112,18 @@
                  :body "Lorem ipsum en francais"
                  :goodbye "Salut de la page parent"
                  :img-url "https://via.placeholder.com/300"})}}}
+
+   ;; Taxons
+   {:db/id "taxon.my-cat"
+    :taxon/slug "my-cat"
+    :taxon/taxonomy :taxon.taxonomy/category
+    :taxon/fields
+    #{{:field/key :title
+       :field/lang :en
+       :field/content (prn-str "My Category")}
+      {:field/key :title
+       :field/lang :fr
+       :field/content (prn-str "Ma Catégorie")}}}
 
    ;; Menu items
    {:db/id "menu.item.home"

--- a/dev/config.edn
+++ b/dev/config.edn
@@ -8,10 +8,11 @@
  ;; the value, then start again. Otherwise you might get a "Backend does not
  ;; exist" error.
  :reinstall-db? true
- :datahike {:backend :jdbc
-            :dbtype "postgresql"
-            :user "breadbox"
-            :dbname "breadbox"
-            :password "breadbox"
+ :datahike {:backend :mem
+            ;:backed :jdbc
+            ;:dbtype "postgresql"
+            ;:user "breadbox"
+            ;:dbname "breadbox"
+            ;:password "breadbox"
             :id "breadbox-db"}
  :connect-flowstorm? false}

--- a/src/systems/bread/alpha/component.cljc
+++ b/src/systems/bread/alpha/component.cljc
@@ -79,7 +79,7 @@
       component
       (let [path (content-path component)
             data (assoc-in data path content)]
-        (recur (parent component) data (component data)))
+        (recur (component-parent component) data (component data)))
       :else
       content)))
 

--- a/src/systems/bread/alpha/component.cljc
+++ b/src/systems/bread/alpha/component.cljc
@@ -63,8 +63,6 @@
 (defn parent [component]
   (:extends (meta component)))
 
-;; TODO layout
-
 (defn component [{::bread/keys [data dispatcher] :as res}]
   (bread/hook res :hook/component (if (:not-found? data)
                                     (:dispatcher/not-found-component dispatcher)
@@ -74,10 +72,6 @@
   (loop [component component
          content content]
     (cond
-      (vector? component)
-      (let [[component coord] component
-            data (assoc-in {} coord content)]
-        (recur (parent component) (component data)))
       component
       (recur (parent component) (component {:content content}))
       :else
@@ -88,7 +82,6 @@
   (let [component (component res)
         parent (parent component)
         body (cond
-               ;; TODO :layout
                (and component
                     (false? (:component/extend? data)))
                (component data)

--- a/src/systems/bread/alpha/dispatcher.cljc
+++ b/src/systems/bread/alpha/dispatcher.cljc
@@ -36,6 +36,12 @@
        (update-in [0 :in] conj sym)
        (conj v))))
 
+(defn pull-spec
+  "Gets the pull spec from the given dispatcher. Adds :db/id to the list
+  of fields to return if it is not already included."
+  [{:dispatcher/keys [pull]}]
+  (vec (if (some #{:db/id} pull) pull (cons :db/id pull))))
+
 (defn pull-query
   "Get a basic query with a (pull ...) form in the :find clause"
   [{:dispatcher/keys [pull]}]

--- a/src/systems/bread/alpha/field.cljc
+++ b/src/systems/bread/alpha/field.cljc
@@ -7,6 +7,7 @@
   (if (map? fields)
     fields
     (into {} (map (fn [row]
-                    (let [{k :field/key content :field/content} (first row)]
+                    (let [field (if (sequential? row) (first row) row)
+                          {k :field/key content :field/content} field]
                       (when k [k (edn/read-string content)])))
                   fields))))

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -6,7 +6,6 @@
     [systems.bread.alpha.field :as field]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.dispatcher :as dispatcher :refer [where pull-query]]
-    [systems.bread.alpha.route :as route]
     [systems.bread.alpha.datastore :as store]))
 
 (defn- syms

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -155,8 +155,8 @@
       :attr/migration "migration.taxons"}
      {:db/ident :taxon/fields
       :db/doc "Translatable fields for this taxon."
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one
+      :db/valueType :db.type/ref
+      :db/cardinality :db.cardinality/many
       :attr/migration "migration.taxons"}]
     {:type :bread/migration
      :migration/dependencies #{:bread.migration/migrations

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -25,6 +25,36 @@
      :migration/dependencies #{}}))
 
 (def
+  ^{:doc "Schema for (site-wide) internationalization (AKA i18n) strings."}
+  i18n
+  (with-meta
+    [{:db/id "migration.i18n"
+      :migration/key :bread.migration/i18n
+      :migration/description "Migration for global translation strings"}
+     {:db/ident :i18n/key
+      :db/doc "The dot-separated path through the (post field, or other) data to the string localized string."
+      :db/valueType :db.type/keyword
+      :db/cardinality :db.cardinality/one
+      :attr/migration "migration.i18n"}
+     {:db/ident :i18n/lang
+      :db/doc "The ISO 639-1 language name as keyword, with optional localization suffix."
+      :db/valueType :db.type/keyword
+      :db/cardinality :db.cardinality/one
+      :attr/migration "migration.i18n"}
+     {:db/ident :i18n/string
+      :db/doc "The value of the string itself, specific to a given path/lang combination."
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one
+      :attr/migration "migration.i18n"}
+     {:db/ident :i18n/translatable?
+      :db/doc "Whether the given attr is translatable."
+      :db/valueType :db.type/boolean
+      :db/cardinality :db.cardinality/one
+      :attr/migration "migration.i18n"}]
+    {:type :bread/migration
+     :migration/dependencies #{:bread.migration/migrations}}))
+
+(def
   ^{:doc "Minimal schema for posts, the central concept of Bread CMS."}
   posts
   (with-meta
@@ -53,6 +83,7 @@
       :db/doc "Zero or more post content fields"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
+      :i18n/translatable? true
       :attr/migration "migration.posts"}
      {:db/ident :post/children
       :db/doc "Entity IDs of child posts, if any"
@@ -92,32 +123,8 @@
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}]
     {:type :bread/migration
-     :migration/dependencies #{:bread.migration/migrations}}))
-
-(def
-  ^{:doc "Schema for (site-wide) internationalization (AKA i18n) strings."}
-  i18n
-  (with-meta
-    [{:db/id "migration.i18n"
-      :migration/key :bread.migration/i18n
-      :migration/description "Migration for global translation strings"}
-     {:db/ident :i18n/key
-      :db/doc "The dot-separated path through the (post field, or other) data to the string localized string."
-      :db/valueType :db.type/keyword
-      :db/cardinality :db.cardinality/one
-      :attr/migration "migration.i18n"}
-     {:db/ident :i18n/lang
-      :db/doc "The ISO 639-1 language name as keyword, with optional localization suffix."
-      :db/valueType :db.type/keyword
-      :db/cardinality :db.cardinality/one
-      :attr/migration "migration.i18n"}
-     {:db/ident :i18n/string
-      :db/doc "The value of the string itself, specific to a given path/lang combination."
-      :db/valueType :db.type/string
-      :db/cardinality :db.cardinality/one
-      :attr/migration "migration.i18n"}]
-    {:type :bread/migration
-     :migration/dependencies #{:bread.migration/migrations}}))
+     :migration/dependencies #{:bread.migration/migrations
+                               :bread.migration/i18n}}))
 
 (def
   ^{:doc "Schema for taxons, ways of subdividing posts arbitrarily."}
@@ -157,9 +164,11 @@
       :db/doc "Translatable fields for this taxon."
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
+      :i18n/translatable? true
       :attr/migration "migration.taxons"}]
     {:type :bread/migration
      :migration/dependencies #{:bread.migration/migrations
+                               :bread.migration/i18n
                                :bread.migration/posts}}))
 
 (def
@@ -328,6 +337,7 @@
       :db/doc "Zero or more user content fields"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
+      :i18n/translatable? true
       :attr/migration "migration.users"}
 
      ;; Authorship of posts
@@ -362,8 +372,8 @@
   ^{:doc "Standard schema for the Bread CMS database."}
   initial
   [migrations
-   posts
    i18n
+   posts
    taxons
    menus
    revisions

--- a/src/systems/bread/alpha/taxon.cljc
+++ b/src/systems/bread/alpha/taxon.cljc
@@ -28,7 +28,8 @@
   (let [{k :dispatcher/key
          params :route/params
          taxonomy :taxon/taxonomy
-         post-type :post/type} dispatcher
+         post-type :post/type
+         post-status :post/status} dispatcher
         db (store/datastore req)
         pull-spec (dispatcher/pull-spec dispatcher)
         ;; If we're querying for fields, we'll want to run a special query
@@ -59,7 +60,7 @@
                          '[?p :post/type ?type])
                        '(post-taxonomized ?p ?taxonomy ?slug)])}
             [post-taxonomized-rule]
-            :post.status/published
+            (or post-status :post.status/published)
             post-type
             taxonomy
             (:slug params)])}

--- a/src/systems/bread/alpha/taxon.cljc
+++ b/src/systems/bread/alpha/taxon.cljc
@@ -1,0 +1,53 @@
+(ns systems.bread.alpha.taxon
+  (:require
+    [clojure.set :refer [rename-keys]]
+    [systems.bread.alpha.core :as bread]
+    [systems.bread.alpha.i18n :as i18n]
+    [systems.bread.alpha.field :as field]
+    [systems.bread.alpha.post :as post]
+    [systems.bread.alpha.dispatcher :as dispatcher]
+    [systems.bread.alpha.datastore :as store]))
+
+(def post-taxonomized-rule
+  '[(post-taxonomized ?post ?taxonomy ?taxon-slug)
+    [?post :post/taxons ?t]
+    [?t :taxon/taxonomy ?taxonomy]
+    [?t :taxon/slug ?taxon-slug]])
+
+(defmethod bread/query ::compact
+  [{k :query/key} data]
+  (-> data
+      (get k)
+      (update :taxon/fields field/compact)
+      (update :post/_taxons #(map post/compact-fields %))
+      (rename-keys {:post/_taxons :taxon/posts})))
+
+(defmethod dispatcher/dispatch :dispatcher.type/taxon
+  [{::bread/keys [dispatcher] :as req}]
+  (let [{k :dispatcher/key
+         params :route/params
+         taxonomy :taxon/taxonomy} dispatcher
+        db (store/datastore req)
+        pull-spec (dispatcher/pull-spec dispatcher)]
+    {:queries [{:query/name ::store/query
+                :query/key k
+                :query/db db
+                :query/args
+                [{:find [(list 'pull '?t pull-spec) '.]
+                  :in '[$ % ?status ?taxonomy ?slug]
+                  :where '[[?t :taxon/slug ?slug]
+                           [?p :post/status ?status]
+                           (post-taxonomized ?p ?taxonomy ?slug)]}
+                 [post-taxonomized-rule]
+                 :post.status/published
+                 taxonomy
+                 (:slug params)]}
+               {:query/name ::compact
+                :query/key k}]}))
+
+(defmethod dispatcher/dispatch :dispatcher.type/tag
+  [{::bread/keys [dispatcher] :as req}]
+  (let [dispatcher (assoc dispatcher
+                          :dispatcher/type :dispatcher.type/taxon
+                          :taxon/taxonomy :taxon.taxonomy/tag)]
+    (dispatcher/dispatch (assoc req ::bread/dispatcher dispatcher))))

--- a/src/systems/bread/alpha/util/datalog.cljc
+++ b/src/systems/bread/alpha/util/datalog.cljc
@@ -4,6 +4,18 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.datastore :as store]))
 
+(defn attr-binding
+  "Parses pull-expr for attr, returning the attr if found as it appears in
+  pull-expr (i.e. as a keyword or a map)"
+  [attr pull-expr]
+  (let [attrs #{attr}
+        map-with-keys (fn [ks x] (when (and (map? x) (some ks (keys x))) x))]
+    (first (keep (some-fn attrs (partial map-with-keys attrs)) pull-expr))))
+
+(comment
+  (attr-binding :taxon/fields [:taxon/fields])
+  (attr-binding :taxon/fields [{:taxon/fields [:field/key :field/content]}]))
+
 (defn attrs
   "Get all schema data available about every attr present in store"
   [store]

--- a/test/systems/bread/alpha/component_test.clj
+++ b/test/systems/bread/alpha/component_test.clj
@@ -18,7 +18,7 @@
   {}
   [:main content])
 
-(defc parent [{:keys [special content]}]
+(defc parent [{:keys [special content extra]}]
   {}
   [:div.parent
    (if special
@@ -28,10 +28,6 @@
 (defc child [{:keys [content]}]
   {:extends parent}
   [:div.child content])
-
-(defc special [{:keys [content]}]
-  {:extends [parent [:special]]}
-  [:div.special-child content])
 
 (defc filtered [{:keys [content]}]
   {}
@@ -56,17 +52,13 @@
     {::bread/data {:content nil
                    :not-found? true}
      ::bread/dispatcher {:dispatcher/component paragraph
-                       :dispatcher/not-found-component not-found-page}}
+                         :dispatcher/not-found-component not-found-page}}
 
     ;; With :extends - parent <- child
     [:div.parent [:div.child "child content"]]
-    {::bread/data {:content "child content"}
+    {::bread/data {:content "child content"
+                   :extra "extra content"}
      ::bread/dispatcher {:dispatcher/component child}}
-
-    ;; With :extends vector - parent <- special
-    [:div.parent [:div.special [:div.special-child "child content"]]]
-    {::bread/data {:content "child content"}
-     ::bread/dispatcher {:dispatcher/component special}}
 
     ;; Test recursive extension - grandparent <- parent <- child
     [:main [:div.parent [:div.child "child content"]]]

--- a/test/systems/bread/alpha/component_test.clj
+++ b/test/systems/bread/alpha/component_test.clj
@@ -18,12 +18,12 @@
   {}
   [:main content])
 
-(defc parent [{:keys [special content extra]}]
-  {}
+(defc parent [{:keys [special extra]}]
+  {:content-path [:special]}
   [:div.parent
-   (if special
-     [:div.special special]
-     content)])
+   special
+   [:div.extra
+    extra]])
 
 (defc child [{:keys [content]}]
   {:extends parent}
@@ -55,16 +55,17 @@
                          :dispatcher/not-found-component not-found-page}}
 
     ;; With :extends - parent <- child
-    [:div.parent [:div.child "child content"]]
+    [:div.parent [:div.child "child content"] [:div.extra "extra content"]]
     {::bread/data {:content "child content"
                    :extra "extra content"}
      ::bread/dispatcher {:dispatcher/component child}}
 
     ;; Test recursive extension - grandparent <- parent <- child
-    [:main [:div.parent [:div.child "child content"]]]
+    [:main [:div.parent [:div.child "child content"] [:div.extra "extra content"]]]
     (let [parent (vary-meta parent assoc :extends grandparent)
           child (vary-meta child assoc :extends parent)]
-      {::bread/data {:content "child content"}
+      {::bread/data {:content "child content"
+                     :extra "extra content"}
        ::bread/dispatcher {:dispatcher/component child}})
 
     ;; With extension disabled

--- a/test/systems/bread/alpha/post_test.clj
+++ b/test/systems/bread/alpha/post_test.clj
@@ -1,8 +1,6 @@
 (ns systems.bread.alpha.post-test
   (:require
     [clojure.test :refer [deftest are]]
-    [kaocha.repl :as k]
-    [systems.bread.alpha.component :refer [defc]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.datastore :as store]
     [systems.bread.alpha.post :as post]
@@ -232,4 +230,5 @@
        :route/params {:lang "en"}})))
 
 (comment
+  (require '[kaocha.repl :as k])
   (k/run))

--- a/test/systems/bread/alpha/taxon_test.clj
+++ b/test/systems/bread/alpha/taxon_test.clj
@@ -100,7 +100,7 @@
         :query/key [:taxon :taxon/fields]
         :query/db db
         :query/args
-        ['{:find [(pull ?f [:db/id :field/key :field/content])]
+        ['{:find [(pull ?f [:db/id :field/key :field/content :field/lang])]
            :in [$ ?t ?lang]
            :where [[?t :taxon/fields ?f]
                    [?f :field/lang ?lang]]}
@@ -110,12 +110,38 @@
         :query/key :taxon}]
       {:dispatcher/type :dispatcher.type/taxon
        :dispatcher/pull [:taxon/slug
-                         {:taxon/fields [:field/key :field/content]}]
+                         {:taxon/fields [:field/key :field/content :field/lang]}]
        :dispatcher/key :taxon
        :taxon/taxonomy :taxon.taxonomy/category
        :route/params {:lang "en" :slug "some-tag"}}
 
       ;; {:uri "/en/tag/some-tag"}
+      ;; :dispatcher.type/tag with :post/type
+      [{:query/name ::store/query
+        :query/key :tag
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
+           :in [$ % ?status ?type ?taxonomy ?slug]
+           :where [[?t :taxon/slug ?slug]
+                   [?p :post/status ?status]
+                   [?p :post/type ?type]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/published
+         :post.type/page
+         :taxon.taxonomy/tag
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :tag}]
+      {:dispatcher/type :dispatcher.type/tag
+       :dispatcher/pull [:taxon/whatever]
+       :dispatcher/key :tag
+       :post/type :post.type/page
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/tag/some-tag"}
+      ;; :dispatcher.type/tag
       [{:query/name ::store/query
         :query/key :tag
         :query/db db

--- a/test/systems/bread/alpha/taxon_test.clj
+++ b/test/systems/bread/alpha/taxon_test.clj
@@ -161,6 +161,48 @@
        :route/params {:lang "en" :slug "some-tag"}}
 
       ;; {:uri "/en/tag/some-tag"}
+      ;; :dispatcher.type/tag with :post/status nil
+      [{:query/name ::store/query
+        :query/key :tag
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
+           :in [$ % ?taxonomy ?slug]
+           :where [[?t :taxon/slug ?slug]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :taxon.taxonomy/tag
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :tag}]
+      {:dispatcher/type :dispatcher.type/tag
+       :dispatcher/pull [:taxon/whatever]
+       :dispatcher/key :tag
+       :post/status nil
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/tag/some-tag"}
+      ;; :dispatcher.type/tag with :post/status false
+      [{:query/name ::store/query
+        :query/key :tag
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
+           :in [$ % ?taxonomy ?slug]
+           :where [[?t :taxon/slug ?slug]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :taxon.taxonomy/tag
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :tag}]
+      {:dispatcher/type :dispatcher.type/tag
+       :dispatcher/pull [:taxon/whatever]
+       :dispatcher/key :tag
+       :post/status false ; same as explicit nil.
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/tag/some-tag"}
       ;; :dispatcher.type/tag
       [{:query/name ::store/query
         :query/key :tag

--- a/test/systems/bread/alpha/taxon_test.clj
+++ b/test/systems/bread/alpha/taxon_test.clj
@@ -1,0 +1,72 @@
+(ns systems.bread.alpha.taxon-test
+  (:require
+    [clojure.test :refer [deftest are]]
+    [systems.bread.alpha.core :as bread]
+    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.taxon :as taxon]
+    [systems.bread.alpha.dispatcher :as dispatcher]
+    [systems.bread.alpha.test-helpers :refer [datastore->plugin
+                                              plugins->loaded]]))
+
+(deftest test-dispatch-taxon-queries
+  (let [db ::FAKEDB
+        app (plugins->loaded [(datastore->plugin db)
+                              (dispatcher/plugin)])
+        ->app (fn [dispatcher]
+                (assoc app ::bread/dispatcher dispatcher))]
+
+    (are
+      [query dispatcher]
+      (= query (-> dispatcher
+                   ->app
+                   (bread/hook ::bread/dispatch)
+                   ::bread/queries))
+
+      ;; {:uri "/en/by-taxon/category/some-tag"}
+      [{:query/name ::store/query
+        :query/key :taxon
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :post/title :custom/key]) .]
+           :in [$ % ?status ?taxonomy ?slug]
+           :where [;; TODO support post/type
+                   [?t :taxon/slug ?slug]
+                   [?p :post/status ?status]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/published
+         :taxon.taxonomy/category
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :taxon}]
+      {:dispatcher/type :dispatcher.type/taxon
+       :dispatcher/pull [:post/title :custom/key]
+       :dispatcher/key :taxon
+       :taxon/taxonomy :taxon.taxonomy/category
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/tag/some-tag"}
+      [{:query/name ::store/query
+        :query/key :tag
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :post/title :custom/key]) .]
+           :in [$ % ?status ?taxonomy ?slug]
+           :where [;; TODO support post/type
+                   [?t :taxon/slug ?slug]
+                   [?p :post/status ?status]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/published
+         :taxon.taxonomy/tag
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :tag}]
+      {:dispatcher/type :dispatcher.type/tag
+       :dispatcher/pull [:post/title :custom/key]
+       :dispatcher/key :tag
+       :route/params {:lang "en" :slug "some-tag"}})))
+
+(comment
+  (require '[kaocha.repl :as k])
+  (k/run))

--- a/test/systems/bread/alpha/taxon_test.clj
+++ b/test/systems/bread/alpha/taxon_test.clj
@@ -30,8 +30,7 @@
         :query/args
         ['{:find [(pull ?t [:db/id :taxon/slug]) .]
            :in [$ % ?status ?taxonomy ?slug]
-           :where [;; TODO support post/type
-                   [?t :taxon/slug ?slug]
+           :where [[?t :taxon/slug ?slug]
                    [?p :post/status ?status]
                    (post-taxonomized ?p ?taxonomy ?slug)]}
          [taxon/post-taxonomized-rule]
@@ -54,8 +53,7 @@
         :query/args
         ['{:find [(pull ?t [:db/id :taxon/slug]) .]
            :in [$ % ?status ?taxonomy ?slug]
-           :where [;; TODO support post/type
-                   [?t :taxon/slug ?slug]
+           :where [[?t :taxon/slug ?slug]
                    [?p :post/status ?status]
                    (post-taxonomized ?p ?taxonomy ?slug)]}
          [taxon/post-taxonomized-rule]
@@ -88,8 +86,7 @@
         :query/args
         ['{:find [(pull ?t [:db/id :taxon/slug]) .]
            :in [$ % ?status ?taxonomy ?slug]
-           :where [;; TODO support post/type
-                   [?t :taxon/slug ?slug]
+           :where [[?t :taxon/slug ?slug]
                    [?p :post/status ?status]
                    (post-taxonomized ?p ?taxonomy ?slug)]}
          [taxon/post-taxonomized-rule]
@@ -141,6 +138,29 @@
        :route/params {:lang "en" :slug "some-tag"}}
 
       ;; {:uri "/en/tag/some-tag"}
+      ;; :dispatcher.type/tag with :post/status
+      [{:query/name ::store/query
+        :query/key :tag
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
+           :in [$ % ?status ?taxonomy ?slug]
+           :where [[?t :taxon/slug ?slug]
+                   [?p :post/status ?status]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/draft
+         :taxon.taxonomy/tag
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :tag}]
+      {:dispatcher/type :dispatcher.type/tag
+       :dispatcher/pull [:taxon/whatever]
+       :dispatcher/key :tag
+       :post/status :post.status/draft
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/tag/some-tag"}
       ;; :dispatcher.type/tag
       [{:query/name ::store/query
         :query/key :tag
@@ -148,8 +168,7 @@
         :query/args
         ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
            :in [$ % ?status ?taxonomy ?slug]
-           :where [;; TODO support post/type
-                   [?t :taxon/slug ?slug]
+           :where [[?t :taxon/slug ?slug]
                    [?p :post/status ?status]
                    (post-taxonomized ?p ?taxonomy ?slug)]}
          [taxon/post-taxonomized-rule]

--- a/test/systems/bread/alpha/taxon_test.clj
+++ b/test/systems/bread/alpha/taxon_test.clj
@@ -202,6 +202,32 @@
        :post/status false ; same as explicit nil.
        :route/params {:lang "en" :slug "some-tag"}}
 
+      #_#_
+      ;; {:uri "/en/tag/some-tag"}
+      ;; TODO Dynamic params from request...
+      [{:query/name ::store/query
+        :query/key :tag
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
+           :in [$ % ?status ?type ?taxonomy ?slug]
+           :where [[?t :taxon/slug ?slug]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/draft ; populated from req
+         :post.type/article ; populated from req
+         :taxon.taxonomy/tag
+         "some-tag"]}
+       {:query/name ::taxon/compact
+        :query/key :tag}]
+      {:dispatcher/type :dispatcher.type/tag
+       :dispatcher/pull [:taxon/whatever]
+       :dispatcher/key :tag
+       :dispatcher/params {:post/status :status
+                           :post/type :type}
+       :route/params {:lang "en" :slug "some-tag"
+                      :type "article" :status "draft"}}
+
       ;; {:uri "/en/tag/some-tag"}
       ;; :dispatcher.type/tag
       [{:query/name ::store/query

--- a/test/systems/bread/alpha/taxon_test.clj
+++ b/test/systems/bread/alpha/taxon_test.clj
@@ -23,11 +23,12 @@
                    ::bread/queries))
 
       ;; {:uri "/en/by-taxon/category/some-tag"}
+      ;; No field I18n.
       [{:query/name ::store/query
         :query/key :taxon
         :query/db db
         :query/args
-        ['{:find [(pull ?t [:db/id :post/title :custom/key]) .]
+        ['{:find [(pull ?t [:db/id :taxon/slug]) .]
            :in [$ % ?status ?taxonomy ?slug]
            :where [;; TODO support post/type
                    [?t :taxon/slug ?slug]
@@ -40,7 +41,76 @@
        {:query/name ::taxon/compact
         :query/key :taxon}]
       {:dispatcher/type :dispatcher.type/taxon
-       :dispatcher/pull [:post/title :custom/key]
+       :dispatcher/pull [:taxon/slug]
+       :dispatcher/key :taxon
+       :taxon/taxonomy :taxon.taxonomy/category
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/by-taxon/category/some-tag"}
+      ;; Query includes field I18n!
+      [{:query/name ::store/query
+        :query/key :taxon
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/slug]) .]
+           :in [$ % ?status ?taxonomy ?slug]
+           :where [;; TODO support post/type
+                   [?t :taxon/slug ?slug]
+                   [?p :post/status ?status]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/published
+         :taxon.taxonomy/category
+         "some-tag"]}
+       {:query/name ::store/query
+        :query/key [:taxon :taxon/fields]
+        :query/db db
+        :query/args
+        ['{:find [(pull ?f [:db/id :field/key :field/content])]
+           :in [$ ?t ?lang]
+           :where [[?t :taxon/fields ?f]
+                   [?f :field/lang ?lang]]}
+         [::bread/data :taxon :db/id]
+         :en]}
+       {:query/name ::taxon/compact
+        :query/key :taxon}]
+      {:dispatcher/type :dispatcher.type/taxon
+       :dispatcher/pull [:taxon/slug :taxon/fields]
+       :dispatcher/key :taxon
+       :taxon/taxonomy :taxon.taxonomy/category
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      ;; {:uri "/en/by-taxon/category/some-tag"}
+      ;; Query includes :taxon/field as a map.
+      [{:query/name ::store/query
+        :query/key :taxon
+        :query/db db
+        :query/args
+        ['{:find [(pull ?t [:db/id :taxon/slug]) .]
+           :in [$ % ?status ?taxonomy ?slug]
+           :where [;; TODO support post/type
+                   [?t :taxon/slug ?slug]
+                   [?p :post/status ?status]
+                   (post-taxonomized ?p ?taxonomy ?slug)]}
+         [taxon/post-taxonomized-rule]
+         :post.status/published
+         :taxon.taxonomy/category
+         "some-tag"]}
+       {:query/name ::store/query
+        :query/key [:taxon :taxon/fields]
+        :query/db db
+        :query/args
+        ['{:find [(pull ?f [:db/id :field/key :field/content])]
+           :in [$ ?t ?lang]
+           :where [[?t :taxon/fields ?f]
+                   [?f :field/lang ?lang]]}
+         [::bread/data :taxon :db/id]
+         :en]}
+       {:query/name ::taxon/compact
+        :query/key :taxon}]
+      {:dispatcher/type :dispatcher.type/taxon
+       :dispatcher/pull [:taxon/slug
+                         {:taxon/fields [:field/key :field/content]}]
        :dispatcher/key :taxon
        :taxon/taxonomy :taxon.taxonomy/category
        :route/params {:lang "en" :slug "some-tag"}}
@@ -50,7 +120,7 @@
         :query/key :tag
         :query/db db
         :query/args
-        ['{:find [(pull ?t [:db/id :post/title :custom/key]) .]
+        ['{:find [(pull ?t [:db/id :taxon/whatever]) .]
            :in [$ % ?status ?taxonomy ?slug]
            :where [;; TODO support post/type
                    [?t :taxon/slug ?slug]
@@ -63,9 +133,11 @@
        {:query/name ::taxon/compact
         :query/key :tag}]
       {:dispatcher/type :dispatcher.type/tag
-       :dispatcher/pull [:post/title :custom/key]
+       :dispatcher/pull [:taxon/whatever]
        :dispatcher/key :tag
-       :route/params {:lang "en" :slug "some-tag"}})))
+       :route/params {:lang "en" :slug "some-tag"}}
+
+      )))
 
 (comment
   (require '[kaocha.repl :as k])


### PR DESCRIPTION
MVP taxon(omy) system. Implements the `:dispatcher.type/taxon` dispatch multimethod and `:dispatcher.type/tag`, a helper that defers to the former multimethod.

TODO:
- [x] post type option
- [x] post status option

TODO in a subsequent PR:
- make query I18n totally generic (beginnings are sketched out here in `schema.cljc` and `datalog.cljc`)
- nicer DSL for composing queries
- dynamic query params (safelisted from request)