### PR TITLE
Dispatch

### DIFF
--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -256,7 +256,7 @@
     (slurp "resources/public/en/parent-page/index.html"))
 
   ;; Test out the whole Bread request lifecycle!
-  (def $req (merge {:uri "/en/cat/my-cat/"} @app))
+  (def $req (assoc @app :uri "/en/cat/my-cat/"))
   (route/params $req (route/match $req))
   (bread/match $router $req)
   (route/dispatcher $req)
@@ -268,6 +268,11 @@
     (bread/hook $ ::bread/dispatch)
     (::bread/queries $))
   (as-> $req $
+    (bread/hook $ ::bread/route)
+    (bread/hook $ ::bread/dispatch)
+    (bread/hook $ ::bread/expand)
+    (::bread/data $))
+  (as-> (assoc @app :uri "/en/404") $
     (bread/hook $ ::bread/route)
     (bread/hook $ ::bread/dispatch)
     (bread/hook $ ::bread/expand)

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -259,18 +259,21 @@
   (def $req (merge {:uri "/en/cat/my-cat/"} @app))
   (route/params $req (route/match $req))
   (bread/match $router $req)
-  (->> $req (bread/dispatch $router) ::bread/dispatcher)
+  (route/dispatcher $req)
   (as-> $req $
-    (bread/dispatch $router $)
+    (bread/hook $ ::bread/route)
+    (::bread/dispatcher $))
+  (as-> $req $
+    (bread/hook $ ::bread/route)
     (bread/hook $ ::bread/dispatch)
     (::bread/queries $))
   (as-> $req $
-    (bread/dispatch $router $)
+    (bread/hook $ ::bread/route)
     (bread/hook $ ::bread/dispatch)
     (bread/hook $ ::bread/expand)
     (::bread/data $))
   (as-> $req $
-    (bread/dispatch $router $)
+    (bread/hook $ ::bread/route)
     (bread/hook $ ::bread/dispatch)
     (bread/hook $ ::bread/expand)
     (bread/hook $ ::bread/render)

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -35,14 +35,6 @@
               :path
               ;; Decode the URL-/dash-encoded string.
               (string/replace #"-%2F" "/"))))
-  ;; If the matched result is a handler (fn), set it as the dispatcher directly.
-  ;; This lets users opt in or out of Bread's routing on a per-route basis.
-  ;; TODO dispatch moves up out of Router protocol;
-  ;; dispatcher returns dispatcher data from the matched route.
-  (bread/dispatch [router req]
-    (let [dispatcher (route/dispatcher req)
-          result (:result (:route/match dispatcher))]
-      (assoc req ::bread/dispatcher (if (fn? result) result dispatcher))))
   (bread/match [router req]
     (reitit/match-by-path router (:uri req)))
   (bread/params [router match]

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -40,11 +40,7 @@
   (bread/params [router match]
     (:path-params match))
   (bread/dispatcher [router match]
-    (:bread/dispatcher (:data match)))
-  (bread/component [router match]
-    (:bread/component (:data match)))
-  (bread/not-found-component [router match]
-    (:bread/not-found-component (:data match))))
+    (:bread/dispatcher (:data match))))
 
 (extend-protocol RoutesCollection
   reitit.core.Router

--- a/src/systems/bread/alpha/component.cljc
+++ b/src/systems/bread/alpha/component.cljc
@@ -67,9 +67,7 @@
   (:content-path (meta component) [:content]))
 
 (defn req->component [{::bread/keys [data dispatcher] :as res}]
-  (bread/hook res :hook/component (if (:not-found? data)
-                                    (:dispatcher/not-found-component dispatcher)
-                                    (:dispatcher/component dispatcher))))
+  (bread/hook res :hook/component (:dispatcher/component dispatcher)))
 
 (defn- render-parent [component data content]
   (loop [component component

--- a/src/systems/bread/alpha/component.cljc
+++ b/src/systems/bread/alpha/component.cljc
@@ -66,8 +66,8 @@
 (defn content-path [component]
   (:content-path (meta component) [:content]))
 
-(defn req->component [{::bread/keys [data dispatcher] :as res}]
-  (bread/hook res :hook/component (:dispatcher/component dispatcher)))
+(defn match [{::bread/keys [data dispatcher] :as res}]
+  (bread/hook res ::match (:dispatcher/component dispatcher)))
 
 (defn- render-parent [component data content]
   (loop [component component
@@ -83,7 +83,7 @@
 
 (defmethod bread/action ::render
   [{::bread/keys [data] :as res} _ _]
-  (let [component (req->component res)
+  (let [component (match res)
         parent (component-parent component)
         body (cond
                (and component

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -23,7 +23,6 @@
 (defprotocol Router
   :extend-via-metadata true
   (path [this route-name params])
-  (dispatch [this req])
   (match [this req])
   (params [this match])
   (dispatcher [this match])

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -25,10 +25,7 @@
   (path [this route-name params])
   (match [this req])
   (params [this match])
-  (dispatcher [this match])
-  ;; TODO redesign component matching
-  (component [this match])
-  (not-found-component [this match]))
+  (dispatcher [this match]))
 
 (defprotocol WatchableRoute
   :extend-via-metadata true

--- a/src/systems/bread/alpha/internal/route_cache.cljc
+++ b/src/systems/bread/alpha/internal/route_cache.cljc
@@ -84,8 +84,8 @@
                          normalized datoms)))))
 
 (defn- eid [req router mapping tx]
-  (as-> router $
-    (bread/component $ (bread/match router req))
+  ;; TODO might have broken during the Great Component Refactor... :shrug:
+  (as-> (component/match req) $
     (component/query $)
     (affecting-attrs $ mapping)
     (datoms-with-attrs $ tx)

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -27,8 +27,6 @@
         match (match req)
         declared (bread/hook req ::dispatcher match)
         component (bread/hook req ::component match)
-        not-found-component
-        (bread/hook req ::not-found-component match)
         {:dispatcher/keys [defaults?]} declared
         keyword->type {:dispatcher.type/home :dispatcher.type/page
                        :dispatcher.type/page :dispatcher.type/page}
@@ -50,7 +48,6 @@
                          :route/match match
                          :route/params (params req match)
                          :dispatcher/component component
-                         :dispatcher/not-found-component not-found-component
                          :dispatcher/key (component/query-key component)
                          :dispatcher/pull (component/query component))]
     (bread/hook req :hook/dispatcher dispatcher')))
@@ -71,10 +68,6 @@
   [_ _ [match]]
   (:bread/component match))
 
-(defmethod bread/action ::not-found-component
-  [req {:keys [router]} [match]]
-  (bread/not-found-component router match))
-
 (defmethod bread/action ::params
   [_ {:keys [router]} [match]]
   (bread/params router match))
@@ -93,8 +86,6 @@
     [{:action/name ::dispatcher :router router}]
     ::component
     [{:action/name ::component :router router}]
-    ::not-found-component
-    [{:action/name ::not-found-component :router router}]
     ::params
     [{:action/name ::params :router router}]
     ::bread/route

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -68,8 +68,8 @@
   (bread/dispatcher router match))
 
 (defmethod bread/action ::component
-  [_ {:keys [router]} [match]]
-  (bread/component router match))
+  [_ _ [match]]
+  (:bread/component match))
 
 (defmethod bread/action ::not-found-component
   [req {:keys [router]} [match]]

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -80,8 +80,8 @@
   (bread/params router match))
 
 (defmethod bread/action ::dispatch
-  [req {:keys [router]} _]
-  (bread/dispatch router req))
+  [req _ _]
+  (assoc req ::bread/dispatcher (dispatcher req)))
 
 (defn plugin [{:keys [router]}]
   {:hooks

--- a/test/systems/bread/alpha/app_test.clj
+++ b/test/systems/bread/alpha/app_test.clj
@@ -183,9 +183,7 @@
                    (bread/params [router match]
                      (:route/params match))
                    (bread/dispatcher [router match]
-                     (:bread/dispatcher match))
-                   (bread/not-found-component [router match]
-                     (:dispatcher/not-found-component (:bread/dispatcher match))))
+                     (:bread/dispatcher match)))
           app (defaults/app {:datastore config
                              :routes {:router router}
                              :i18n {:supported-langs #{:en :fr}}})

--- a/test/systems/bread/alpha/app_test.clj
+++ b/test/systems/bread/alpha/app_test.clj
@@ -169,9 +169,7 @@
                    (bread/component [_ match]
                      (:dispatcher/component (:bread/dispatcher match)))
                    (bread/not-found-component [router match]
-                     (:dispatcher/not-found-component (:bread/dispatcher match)))
-                   (bread/dispatch [router req]
-                     (assoc req ::bread/dispatcher (route/dispatcher req))))
+                     (:dispatcher/not-found-component (:bread/dispatcher match))))
           app (defaults/app {:datastore config
                              :routes {:router router}
                              :i18n {:supported-langs #{:en :fr}}})

--- a/test/systems/bread/alpha/app_test.clj
+++ b/test/systems/bread/alpha/app_test.clj
@@ -3,10 +3,9 @@
   systems.bread.alpha.app-test
   (:require
     [clojure.test :refer [are deftest is testing]]
-    [kaocha.repl :as k]
     [systems.bread.alpha.defaults :as defaults]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.component :as component]
+    [systems.bread.alpha.component :refer [defc]]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.datastore :as store]
     [systems.bread.alpha.post :as post]
@@ -86,26 +85,37 @@
 
 (use-datastore :each config)
 
-(component/defc home [{:keys [post]}]
+(defc layout [{:keys [content not-found? i18n]}]
+  {}
+  [:body
+   (if not-found?
+     [:main
+      (:not-found i18n)]
+     content)])
+
+(defc home [{:keys [post]}]
   {:query [{:post/fields [:field/key :field/content]}]
-   :key :post}
+   :key :post
+   :extends layout}
   (let [post (post/compact-fields post)
         {:keys [title simple]} (:post/fields post)]
     [:main
      [:h1 title]
      [:p (:hello simple)]]))
 
-(component/defc page [{:keys [post]}]
+(defc page [{:keys [post]}]
   {:query [{:post/fields [:field/key :field/content]}]
-   :key :post}
+   :key :post
+   :extends layout}
   (let [post (post/compact-fields post)
         {:keys [title simple]} (:post/fields post)]
     [:main.interior-page
      [:h1 title]
      [:p (:hello simple)]]))
 
-(component/defc not-found [{:keys [i18n]}]
+(defc not-found [{:keys [i18n]}]
   {}
+  (prn 'YES 'NOT)
   [:main (:not-found i18n)])
 
 (deftest test-app-lifecycle
@@ -115,34 +125,40 @@
                   {:bread/dispatcher {:dispatcher/type :dispatcher.type/page
                                       :dispatcher/key :post
                                       :dispatcher/component home}
+                   :bread/component home
                    :route/params {:lang "en"}}
                   "/fr"
                   {:bread/dispatcher {:dispatcher/type :dispatcher.type/page
                                       :dispatcher/key :post
                                       :dispatcher/component home}
+                   :bread/component home
                    :route/params {:lang "fr"}}
                   "/en/parent-page"
                   {:bread/dispatcher {:dispatcher/type :dispatcher.type/page
                                       :dispatcher/key :post
                                       :dispatcher/component page}
+                   :bread/component page
                    :route/params {:lang "en"
                                   :slugs "parent-page"}}
                   "/en/parent-page/child-page"
                   {:bread/dispatcher {:dispatcher/type :dispatcher.type/page
                                       :dispatcher/key :post
                                       :dispatcher/component page}
+                   :bread/component page
                    :route/params {:lang "en"
                                   :slugs "parent-page/child-page"}}
                   "/fr/parent-page"
                   {:bread/dispatcher {:dispatcher/type :dispatcher.type/page
                                       :dispatcher/key :post
                                       :dispatcher/component page}
+                   :bread/component page
                    :route/params {:lang "fr"
                                   :slugs "parent-page"}}
                   "/fr/parent-page/child-page"
                   {:bread/dispatcher {:dispatcher/type :dispatcher.type/page
                                       :dispatcher/key :post
                                       :dispatcher/component page}
+                   :bread/component page
                    :route/params {:lang "fr"
                                   :slugs "parent-page/child-page"}}
                   "/en/404"
@@ -150,6 +166,7 @@
                                       :dispatcher/key :post
                                       :dispatcher/component page
                                       :dispatcher/not-found-component not-found}
+                   :bread/component page
                    :route/params {:lang "en"
                                   :slugs "not-found"}}
                   "/fr/404"
@@ -157,6 +174,7 @@
                                       :dispatcher/key :post
                                       :dispatcher/component page
                                       :dispatcher/not-found-component not-found}
+                   :bread/component page
                    :route/params {:lang "fr"
                                   :slugs "not-found"}}}
           router (reify bread/Router
@@ -166,8 +184,6 @@
                      (:route/params match))
                    (bread/dispatcher [router match]
                      (:bread/dispatcher match))
-                   (bread/component [_ match]
-                     (:dispatcher/component (:bread/dispatcher match)))
                    (bread/not-found-component [router match]
                      (:dispatcher/not-found-component (:bread/dispatcher match))))
           app (defaults/app {:datastore config
@@ -179,50 +195,57 @@
         (= expected (select-keys res [:body]))
 
         {:body
-         [:main
-          [:h1 "Home Page"]
-          [:p "Hi!"]]}
+         [:body [:main
+                 [:h1 "Home Page"]
+                 [:p "Hi!"]]]}
         (handler {:uri "/en"})
 
         {:body
-         [:main
-          [:h1 "Page D'Accueil"]
-          [:p "Allo!"]]}
+         [:body [:main
+                 [:h1 "Page D'Accueil"]
+                 [:p "Allo!"]]]}
         (handler {:uri "/fr"})
 
         {:body
-         [:main.interior-page
-          [:h1 "Parent Page"]
-          [:p "Hello from parent"]]}
+         [:body
+          [:main.interior-page
+           [:h1 "Parent Page"]
+           [:p "Hello from parent"]]]}
         (handler {:uri "/en/parent-page"})
 
         {:body
-         [:main.interior-page
-          [:h1 "La Page Parent"]
-          [:p "Bonjour de parent"]]}
+         [:body
+          [:main.interior-page
+           [:h1 "La Page Parent"]
+           [:p "Bonjour de parent"]]]}
         (handler {:uri "/fr/parent-page"})
 
         {:body
-         [:main.interior-page
-          [:h1 "Child Page"]
-          [:p "Hello from child"]]}
+         [:body
+          [:main.interior-page
+           [:h1 "Child Page"]
+           [:p "Hello from child"]]]}
         (handler {:uri "/en/parent-page/child-page"})
 
         {:body
-         [:main.interior-page
-          [:h1 "La Page Enfant"]
-          [:p "Bonjour d'enfant"]]}
+         [:body
+          [:main.interior-page
+           [:h1 "La Page Enfant"]
+           [:p "Bonjour d'enfant"]]]}
         (handler {:uri "/fr/parent-page/child-page"})
 
         {:body
-         [:main "404 Not Found"]}
+         [:body
+          [:main "404 Not Found"]]}
         (handler {:uri "/en/404"})
 
         {:body
-         [:main "404 Pas Trouvé"]}
+         [:body
+          [:main "404 Pas Trouvé"]]}
         (handler {:uri "/fr/404"})
 
         ))))
 
 (comment
+  (require '[kaocha.repl :as k])
   (k/run))

--- a/test/systems/bread/alpha/component_test.clj
+++ b/test/systems/bread/alpha/component_test.clj
@@ -1,7 +1,6 @@
 (ns systems.bread.alpha.component-test
   (:require
     [clojure.test :refer [deftest are is testing]]
-    [kaocha.repl :as k]
     [systems.bread.alpha.component :as component :refer [defc]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded]]))
@@ -64,7 +63,7 @@
     ;; With plugins filtering the component
     [:div.plugin "filtered content"]
     (assoc (plugins->loaded [{:hooks
-                              {:hook/component
+                              {::component/match
                                [{:action/name ::filtered
                                  :component filtered}]}}])
            ::bread/data {:content "content"})))
@@ -99,4 +98,5 @@
          (component/query next-level))))
 
 (comment
+  (require '[kaocha.repl :as k])
   (k/run))

--- a/test/systems/bread/alpha/component_test.clj
+++ b/test/systems/bread/alpha/component_test.clj
@@ -10,10 +10,6 @@
   {}
   [:p content])
 
-(defc not-found-page [_]
-  {}
-  [:div "404 Not Found"])
-
 (defc grandparent [{:keys [content]}]
   {}
   [:main content])
@@ -45,14 +41,6 @@
     [:p "the content"]
     {::bread/data {:content "the content"}
      ::bread/dispatcher {:dispatcher/component paragraph}}
-
-    ;; 404 Not Found
-    ;; dispatcher/expander are responsible for setting up this data
-    [:div "404 Not Found"]
-    {::bread/data {:content nil
-                   :not-found? true}
-     ::bread/dispatcher {:dispatcher/component paragraph
-                         :dispatcher/not-found-component not-found-page}}
 
     ;; With :extends - parent <- child
     [:div.parent [:div.child "child content"] [:div.extra "extra content"]]

--- a/test/systems/bread/alpha/route_test.clj
+++ b/test/systems/bread/alpha/route_test.clj
@@ -1,7 +1,6 @@
 (ns systems.bread.alpha.route-test
   (:require
     [clojure.test :refer [deftest are is testing]]
-    [kaocha.repl :as k]
     [systems.bread.alpha.component :as component]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.route :as route]
@@ -208,4 +207,5 @@
     ))
 
 (comment
+  (require '[kaocha.repl :as k])
   (k/run))

--- a/test/systems/bread/alpha/route_test.clj
+++ b/test/systems/bread/alpha/route_test.clj
@@ -44,7 +44,6 @@
                 "/en/not-found"
                 {:bread/dispatcher {:dispatcher/type :whatevs}
                  :bread/component 'page
-                 :bread/not-found-component 'not-found
                  :route/params {:lang "en"
                                 :slug "not-found"}}
                 "/overridden"
@@ -71,7 +70,6 @@
          {:dispatcher/type :dispatcher.type/page
           :dispatcher/i18n? true
           :dispatcher/component nil
-          :dispatcher/not-found-component nil
           :dispatcher/key nil
           :dispatcher/pull nil
           :post/type :post.type/page
@@ -82,7 +80,6 @@
          {:dispatcher/type :dispatcher.type/page
           :dispatcher/i18n? true
           :dispatcher/component 'home
-          :dispatcher/not-found-component nil
           :dispatcher/key :home
           :dispatcher/pull [:db/id :home/slug]
           :post/type :post.type/page
@@ -96,7 +93,6 @@
           :dispatcher/i18n? true
           :post/type :post.type/page
           :dispatcher/component 'page
-          :dispatcher/not-found-component nil
           :dispatcher/key :page
           :dispatcher/pull [:db/id :page/slug]
           :route/params {:lang "en" :slug "keyword"}
@@ -109,7 +105,6 @@
           :dispatcher/i18n? true
           :post/type :post.type/page
           :dispatcher/component 'page
-          :dispatcher/not-found-component nil
           :dispatcher/key :page
           :dispatcher/pull [:db/id :page/slug]
           :route/params {:lang "en"
@@ -123,7 +118,6 @@
          {:dispatcher/type :dispatcher.type/page
           :dispatcher/i18n? true
           :dispatcher/component 'page
-          :dispatcher/not-found-component nil
           :dispatcher/key :page
           :dispatcher/pull [:db/id :page/slug]
           :post/type :post.type/page
@@ -138,7 +132,6 @@
          {:dispatcher/type :dispatcher.type/page
           :dispatcher/i18n? false
           :dispatcher/component 'page
-          :dispatcher/not-found-component nil
           :dispatcher/key :page
           :dispatcher/pull [:db/id :page/slug]
           :post/type :post.type/page
@@ -151,7 +144,6 @@
          {:dispatcher/type :whatevs
           :dispatcher/defaults? false
           :dispatcher/component 'page
-          :dispatcher/not-found-component nil
           :dispatcher/key :page
           :dispatcher/pull [:db/id :page/slug]
           :route/params {:lang "en"
@@ -166,7 +158,6 @@
          {:dispatcher/type :whatevs
           :dispatcher/i18n? true
           :dispatcher/component 'page
-          :dispatcher/not-found-component 'not-found
           :dispatcher/key :page
           :post/type :post.type/page
           :dispatcher/pull [:db/id :page/slug]
@@ -174,7 +165,6 @@
                          :slug "not-found"}
           :route/match {:bread/dispatcher {:dispatcher/type :whatevs}
                         :bread/component 'page
-                        :bread/not-found-component 'not-found
                         :route/params {:lang "en"
                                        :slug "not-found"}}}
          "/en/not-found"
@@ -182,7 +172,6 @@
          {:dispatcher/type :whatevs
           :dispatcher/i18n? true
           :dispatcher/component nil
-          :dispatcher/not-found-component nil
           :dispatcher/key nil
           :dispatcher/pull nil
           :post/type :post.type/page

--- a/test/systems/bread/alpha/test_helpers.clj
+++ b/test/systems/bread/alpha/test_helpers.clj
@@ -85,7 +85,5 @@
                  (bread/component [_ match]
                    (:bread/component match))
                  (bread/not-found-component [_ match]
-                   (:bread/not-found-component match))
-                 (bread/dispatch [router req]
-                   (assoc req ::bread/dispatcher (route/dispatcher req))))]
+                   (:bread/not-found-component match)))]
     (route/plugin {:router router})))

--- a/test/systems/bread/alpha/test_helpers.clj
+++ b/test/systems/bread/alpha/test_helpers.clj
@@ -81,9 +81,5 @@
                  (bread/params [_ match]
                    (:route/params match))
                  (bread/dispatcher [_ match]
-                   (:bread/dispatcher match))
-                 (bread/component [_ match]
-                   (:bread/component match))
-                 (bread/not-found-component [_ match]
-                   (:bread/not-found-component match)))]
+                   (:bread/dispatcher match)))]
     (route/plugin {:router router})))


### PR DESCRIPTION
#59 refactor how dispatcher/components work:

- The `::route/component` hook now does a simple `:bread/component` lookup on the match
- `component/match` replaces `bread/component`
- Layout now checks `:not-found?` by convention - no more `bread/not-found-component`