### PR TITLE
OVERHAUL DATABASE API

### DIFF
--- a/cms/systems/bread/alpha/cms/defaults.cljc
+++ b/cms/systems/bread/alpha/cms/defaults.cljc
@@ -114,7 +114,7 @@
       (update :status #(or % (if (:not-found? data) 404 200)))
       (update-in [:headers "content-type"] #(or % default-content-type))))
 
-(defn plugins [{:keys [datastore
+(defn plugins [{:keys [db
                        routes
                        i18n
                        navigation
@@ -131,7 +131,7 @@
         [(dispatcher/plugin)
          (query/plugin)
          (component/plugin components)
-         (when (not (false? datastore)) (store/plugin datastore))
+         (when (not (false? db)) (store/plugin db))
          (when (not (false? routes)) (route/plugin routes))
          (when (not (false? i18n)) (i18n/plugin i18n))
          (when (not (false? navigation)) (nav/plugin navigation))

--- a/cms/systems/bread/alpha/cms/defaults.cljc
+++ b/cms/systems/bread/alpha/cms/defaults.cljc
@@ -3,7 +3,7 @@
     [systems.bread.alpha.cache :as cache]
     [systems.bread.alpha.component :as component]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.navigation :as nav]
     [systems.bread.alpha.query :as query]

--- a/cms/systems/bread/alpha/cms/defaults.cljc
+++ b/cms/systems/bread/alpha/cms/defaults.cljc
@@ -27,7 +27,7 @@
     :post/type :post.type/page
     :post/slug ""
     :post/status :post.status/published
-    :post/fields
+    :translatable/fields
     #{{:field/key :title
        :field/lang :en
        :field/content (prn-str "The Title")}
@@ -38,7 +38,7 @@
     :post/type :post.type/page
     :post/slug "child-page"
     :post/status :post.status/published
-    :post/fields
+    :translatable/fields
     #{{:field/key :title
        :field/lang :en
        :field/content (prn-str "Child")}
@@ -49,7 +49,7 @@
     :post/type :post.type/page
     :post/slug "sister-page"
     :post/status :post.status/draft
-    :post/fields
+    :translatable/fields
     #{{:field/key :title
        :field/lang :en
        :field/content (prn-str "Sister")}
@@ -61,7 +61,7 @@
     :post/slug "parent-page"
     :post/children ["page.child"]
     :post/status :post.status/published
-    :post/fields
+    :translatable/fields
     #{{:field/key :title
        :field/lang :en
        :field/content (prn-str "Parent Page")}
@@ -70,19 +70,12 @@
        :field/content (prn-str "La Page Parent")}}}
 
    ;; Site-wide translations
-   #:i18n{:lang :en
-          :key :not-found
-          :string "404 Not Found"}
-   #:i18n{:lang :fr
-          :key :not-found
-          :string "404 Pas Trouvé"}
-   #:i18n{:lang :fr
-          :key :breadbox
-          :string "Boite à pain"}
-   #:i18n{:lang :en
-          :key :breadbox
-          :string "Breadbox"}
-   ])
+   {:field/lang :en
+    :field/key :not-found
+    :field/content "404 Not Found"}
+   {:field/lang :es
+    :field/key :not-found
+    :field/content "404 Pas Trouvé"}])
 
 (defmethod bread/action ::request-data
   [req _ _]

--- a/cms/systems/bread/alpha/cms/defaults.cljc
+++ b/cms/systems/bread/alpha/cms/defaults.cljc
@@ -3,7 +3,7 @@
     [systems.bread.alpha.cache :as cache]
     [systems.bread.alpha.component :as component]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.navigation :as nav]
     [systems.bread.alpha.query :as query]
@@ -124,7 +124,7 @@
         [(dispatcher/plugin)
          (query/plugin)
          (component/plugin components)
-         (when (not (false? db)) (store/plugin db))
+         (when (not (false? db)) (db/plugin db))
          (when (not (false? routes)) (route/plugin routes))
          (when (not (false? i18n)) (i18n/plugin i18n))
          (when (not (false? navigation)) (nav/plugin navigation))

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -157,7 +157,7 @@
     defaults))
 
 (defmethod ig/init-key :ring/session-store
-  [_ {store-type :store/type {conn :datastore/connection} :store/datastore}]
+  [_ {store-type :store/type {conn :db/connection} :store/datastore}]
   ;; TODO extend with a multimethod??
   (when (= :datalog store-type)
     (auth/session-store conn)))
@@ -166,7 +166,7 @@
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
   (store/create! db-config {:force? force?})
-  (assoc db-config :datastore/connection (store/connect db-config)))
+  (assoc db-config :db/connection (store/connect db-config)))
 
 (defmethod ig/halt-key! :bread/datastore
   [_ {:keys [recreate?] :as db-config}]

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -293,7 +293,7 @@
   (defn q [& args]
     (apply
       store/q
-      (store/datastore (->app $req))
+      (store/database (->app $req))
       args))
 
   (def coby
@@ -346,7 +346,7 @@
   ;; We can query for every :db/ident in the database:
   (require '[systems.bread.alpha.util.datalog :as datalog])
   (def idents
-    (map :db/ident (datalog/attrs (store/datastore (->app $req)))))
+    (map :db/ident (datalog/attrs (store/database (->app $req)))))
 
   ;; Now we can scan a given route for db idents...
   (def route
@@ -357,7 +357,7 @@
 
   ;; Before the next step, we query for all refs in the db:
   (def refs
-    (datalog/attrs-by-type (store/datastore (->app $req)) :db.type/ref))
+    (datalog/attrs-by-type (store/database (->app $req)) :db.type/ref))
 
   ;; One more thing: we need to keep track of the attrs we've seen so far:
   (def seen

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -160,7 +160,7 @@
     defaults))
 
 (defmethod ig/init-key :ring/session-store
-  [_ {store-type :store/type {conn :db/connection} :store/datastore}]
+  [_ {store-type :store/type {conn :db/connection} :store/db}]
   ;; TODO extend with a multimethod??
   (when (= :datalog store-type)
     (auth/session-store conn)))

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -35,13 +35,16 @@
 (defc home-page
   [{:keys [lang user post]}]
   {:key :post
-   :query [{:post/fields ['*]}]}
+   :query [:post/children
+           :post/slug
+           :post/authors
+           {:translatable/fields ['*]}]}
   [:html {:lang lang}
    [:head
     [:meta {:content-type "utf-8"}]
     [:title "Home | BreadCMS"]]
    [:body
-    [:h1 (:title (:post/fields post))]
+    [:h1 (:title (:translatable/fields post))]
     [:pre (pr-str post)]
     [:pre (pr-str (user/can? user :edit-posts))]]])
 
@@ -162,13 +165,13 @@
   (when (= :datalog store-type)
     (auth/session-store conn)))
 
-(defmethod ig/init-key :bread/datastore
+(defmethod ig/init-key :bread/db
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
   (store/create! db-config {:force? force?})
   (assoc db-config :db/connection (store/connect db-config)))
 
-(defmethod ig/halt-key! :bread/datastore
+(defmethod ig/halt-key! :bread/db
   [_ {:keys [recreate?] :as db-config}]
   ;; TODO call datahike API directly
   (when recreate? (store/delete! db-config)))
@@ -241,7 +244,7 @@
   (:ring/session-store @system)
   (:bread/app @system)
   (:bread/router @system)
-  (:bread/datastore @system)
+  (:bread/db @system)
   (:bread/profilers @system)
   (restart! (-> "dev/main.edn" aero/read-config))
 

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -15,7 +15,7 @@
     [systems.bread.alpha.core :as bread]
     ;; TODO load components dynamicaly using sci
     [systems.bread.alpha.component :refer [defc]]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.user :as user]
     [systems.bread.alpha.cms.defaults :as defaults]
     [systems.bread.alpha.plugin.auth :as auth]

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -165,13 +165,13 @@
 (defmethod ig/init-key :bread/datastore
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
-  (store/create-database! db-config {:force? force?})
-  (assoc db-config :datastore/connection (store/connect! db-config)))
+  (store/create! db-config {:force? force?})
+  (assoc db-config :datastore/connection (store/connect db-config)))
 
 (defmethod ig/halt-key! :bread/datastore
   [_ {:keys [recreate?] :as db-config}]
   ;; TODO call datahike API directly
-  (when recreate? (store/delete-database! db-config)))
+  (when recreate? (store/delete! db-config)))
 
 (defmethod ig/init-key :bread/router [_ router]
   router)

--- a/cms/systems/bread/alpha/cms/scratch.clj
+++ b/cms/systems/bread/alpha/cms/scratch.clj
@@ -192,13 +192,13 @@
 (defmethod ig/init-key :bread/datastore
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
-  (store/create-database! db-config {:force? force?})
-  (assoc db-config :datastore/connection (store/connect! db-config)))
+  (store/create! db-config {:force? force?})
+  (assoc db-config :datastore/connection (store/connect db-config)))
 
 (defmethod ig/halt-key! :bread/datastore
   [_ {:keys [recreate?] :as db-config}]
   ;; TODO call datahike API directly
-  (when recreate? (store/delete-database! db-config)))
+  (when recreate? (store/delete! db-config)))
 
 (defmethod ig/init-key :bread/router [_ router]
   router)

--- a/cms/systems/bread/alpha/cms/scratch.clj
+++ b/cms/systems/bread/alpha/cms/scratch.clj
@@ -16,7 +16,7 @@
     [systems.bread.alpha.dispatcher :as dispatcher]
     ;; TODO load components dynamicaly using sci
     [systems.bread.alpha.component :refer [defc]]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.cms.defaults :as defaults]
     [systems.bread.alpha.plugin.auth :as auth])
   (:import
@@ -192,13 +192,13 @@
 (defmethod ig/init-key :bread/db
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
-  (store/create! db-config {:force? force?})
-  (assoc db-config :db/connection (store/connect db-config)))
+  (db/create! db-config {:force? force?})
+  (assoc db-config :db/connection (db/connect db-config)))
 
 (defmethod ig/halt-key! :bread/db
   [_ {:keys [recreate?] :as db-config}]
   ;; TODO call datahike API directly
-  (when recreate? (store/delete! db-config)))
+  (when recreate? (db/delete! db-config)))
 
 (defmethod ig/init-key :bread/router [_ router]
   router)
@@ -314,23 +314,23 @@
   ;; And, while we're at it, define a query helper:
   (defn q [& args]
     (apply
-      store/q
-      (store/database (->app $req))
+      db/q
+      (db/database (->app $req))
       args))
-  (store/q (store/database (:bread/app @system))
-           '{:find [(pull ?e [*])]
-             :in [$]
-             :where [[?e :user/username "coby"]]})
-  (store/q (store/database (:bread/app @system))
-           '{:find [(pull ?e [*])]
-             :in [$]
-             :where [[?e :user/locked-at]]})
-  (store/transact (store/connection (:bread/app @system))
-                  [{:db/foo 85
-                    :user/locked-at (java.util.Date.)}])
-  (store/transact (store/connection (:bread/app @system))
-                  [{:user/username "coby"
-                    :user/locked-at (java.util.Date.)}])
+  (db/q (db/database (:bread/app @system))
+        '{:find [(pull ?e [*])]
+          :in [$]
+          :where [[?e :user/username "coby"]]})
+  (db/q (db/database (:bread/app @system))
+        '{:find [(pull ?e [*])]
+          :in [$]
+          :where [[?e :user/locked-at]]})
+  (db/transact (db/connection (:bread/app @system))
+               [{:db/foo 85
+                 :user/locked-at (java.util.Date.)}])
+  (db/transact (db/connection (:bread/app @system))
+               [{:user/username "coby"
+                 :user/locked-at (java.util.Date.)}])
 
   ;; SITEMAP DESIGN
 
@@ -338,7 +338,7 @@
   ;; We can query for every :db/ident in the database:
   (require '[systems.bread.alpha.util.datalog :as datalog])
   (def idents
-    (map :db/ident (datalog/attrs (store/database (->app $req)))))
+    (map :db/ident (datalog/attrs (db/database (->app $req)))))
 
   ;; Now we can scan a given route for db idents...
   (def route
@@ -349,7 +349,7 @@
 
   ;; Before the next step, we query for all refs in the db:
   (def refs
-    (datalog/attrs-by-type (store/database (->app $req)) :db.type/ref))
+    (datalog/attrs-by-type (db/database (->app $req)) :db.type/ref))
 
   ;; One more thing: we need to keep track of the attrs we've seen so far:
   (def seen

--- a/cms/systems/bread/alpha/cms/scratch.clj
+++ b/cms/systems/bread/alpha/cms/scratch.clj
@@ -189,13 +189,13 @@
   (when-let [prom (stop-server :timeout 100)]
     @prom))
 
-(defmethod ig/init-key :bread/datastore
+(defmethod ig/init-key :bread/db
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
   (store/create! db-config {:force? force?})
   (assoc db-config :db/connection (store/connect db-config)))
 
-(defmethod ig/halt-key! :bread/datastore
+(defmethod ig/halt-key! :bread/db
   [_ {:keys [recreate?] :as db-config}]
   ;; TODO call datahike API directly
   (when recreate? (store/delete! db-config)))
@@ -263,7 +263,7 @@
   (:ring/wrap-defaults @system)
   (:bread/app @system)
   (:bread/router @system)
-  (:bread/datastore @system)
+  (:bread/db @system)
   (:bread/profilers @system)
   (restart! (-> "dev/cgi.edn" aero/read-config))
 

--- a/cms/systems/bread/alpha/cms/scratch.clj
+++ b/cms/systems/bread/alpha/cms/scratch.clj
@@ -315,13 +315,13 @@
   (defn q [& args]
     (apply
       store/q
-      (store/datastore (->app $req))
+      (store/database (->app $req))
       args))
-  (store/q (store/datastore (:bread/app @system))
+  (store/q (store/database (:bread/app @system))
            '{:find [(pull ?e [*])]
              :in [$]
              :where [[?e :user/username "coby"]]})
-  (store/q (store/datastore (:bread/app @system))
+  (store/q (store/database (:bread/app @system))
            '{:find [(pull ?e [*])]
              :in [$]
              :where [[?e :user/locked-at]]})
@@ -338,7 +338,7 @@
   ;; We can query for every :db/ident in the database:
   (require '[systems.bread.alpha.util.datalog :as datalog])
   (def idents
-    (map :db/ident (datalog/attrs (store/datastore (->app $req)))))
+    (map :db/ident (datalog/attrs (store/database (->app $req)))))
 
   ;; Now we can scan a given route for db idents...
   (def route
@@ -349,7 +349,7 @@
 
   ;; Before the next step, we query for all refs in the db:
   (def refs
-    (datalog/attrs-by-type (store/datastore (->app $req)) :db.type/ref))
+    (datalog/attrs-by-type (store/database (->app $req)) :db.type/ref))
 
   ;; One more thing: we need to keep track of the attrs we've seen so far:
   (def seen

--- a/cms/systems/bread/alpha/cms/scratch.clj
+++ b/cms/systems/bread/alpha/cms/scratch.clj
@@ -193,7 +193,7 @@
   [_ {:keys [recreate? force?] :as db-config}]
   ;; TODO call datahike API directly
   (store/create! db-config {:force? force?})
-  (assoc db-config :datastore/connection (store/connect db-config)))
+  (assoc db-config :db/connection (store/connect db-config)))
 
 (defmethod ig/halt-key! :bread/datastore
   [_ {:keys [recreate?] :as db-config}]

--- a/cms/systems/bread/alpha/cms/scratch.clj
+++ b/cms/systems/bread/alpha/cms/scratch.clj
@@ -16,7 +16,7 @@
     [systems.bread.alpha.dispatcher :as dispatcher]
     ;; TODO load components dynamicaly using sci
     [systems.bread.alpha.component :refer [defc]]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.cms.defaults :as defaults]
     [systems.bread.alpha.plugin.auth :as auth])
   (:import

--- a/cms/systems/bread/alpha/user.cljc
+++ b/cms/systems/bread/alpha/user.cljc
@@ -33,7 +33,7 @@
   )
 
 (defn fetch [req id]
-  (store/q (store/datastore req)
+  (store/q (store/database req)
            '{:find [(pull ?e [:db/id
                               :user/username
                               :user/uuid

--- a/cms/systems/bread/alpha/user.cljc
+++ b/cms/systems/bread/alpha/user.cljc
@@ -1,7 +1,7 @@
 (ns systems.bread.alpha.user
   (:require
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]))
+    [systems.bread.alpha.database :as db]))
 
 (defn abilities [{:user/keys [roles]}]
   (reduce (fn [user-abilities role]
@@ -33,19 +33,19 @@
   )
 
 (defn fetch [req id]
-  (store/q (store/database req)
-           '{:find [(pull ?e [:db/id
-                              :user/username
-                              :user/uuid
-                              :user/email
-                              :user/name
-                              :user/lang
-                              :user/slug
-                              {:user/roles [:role/key
-                                            {:role/abilities
-                                             [:ability/key]}]}]) .]
-             :in [$ ?e]}
-           id))
+  (db/q (db/database req)
+        '{:find [(pull ?e [:db/id
+                           :user/username
+                           :user/uuid
+                           :user/email
+                           :user/name
+                           :user/lang
+                           :user/slug
+                           {:user/roles [:role/key
+                                         {:role/abilities
+                                          [:ability/key]}]}]) .]
+          :in [$ ?e]}
+        id))
 
 (defmethod bread/action ::query [req {:keys [data-key]} _]
   (if-let [uid (->> req :session :user (bread/hook req ::from-session) :db/id)]

--- a/cms/systems/bread/alpha/user.cljc
+++ b/cms/systems/bread/alpha/user.cljc
@@ -1,7 +1,7 @@
 (ns systems.bread.alpha.user
   (:require
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 (defn abilities [{:user/keys [roles]}]
   (reduce (fn [user-abilities role]

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -58,9 +58,9 @@
 
 (defonce app (atom nil))
 
-(def $config {:datastore/type :datahike
+(def $config {:db/type :datahike
               :store (:datahike env)
-              :datastore/initial-txns
+              :db/initial-txns
               data/initial-content})
 
 (defn hello-handler [_]

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -14,7 +14,7 @@
     [kaocha.repl :as k]
     [systems.bread.alpha.defaults :as defaults]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.plugin.datahike :as dh]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.plugin.reitit]
@@ -141,7 +141,7 @@
   :start (when (:reinstall-db? env)
            (println "REINSTALLING DATABASE.")
            (try
-             (store/create! $config {:force? true})
+             (db/create! $config {:force? true})
              (catch clojure.lang.ExceptionInfo e
                (println (format "Error reinstalling database: %s"
                                 (ex-message e)))
@@ -149,7 +149,7 @@
   :stop (when (:reinstall-db? env)
           (println "DELETING DEV DATABASE.")
           (try
-            (store/delete! $config)
+            (db/delete! $config)
             (catch clojure.lang.ExceptionInfo e
               (println (format "Error deleting database on stop: %s"
                                (ex-message e)))
@@ -215,7 +215,7 @@
                              (if internal?
                                req
                                (let [uniq (str (gensym "new-"))]
-                                 (store/add-txs
+                                 (db/add-txs
                                    req
                                    [{:post/slug uniq
                                      :post/type :post.type/page
@@ -288,7 +288,7 @@
     (select-keys $ [:status :body :headers]))
 
   (defn q [query & args]
-    (apply store/q (store/database $req) query args))
+    (apply db/q (db/database $req) query args))
 
   (q '{:find [(pull ?e [:db/id :post/slug])],
        :in [$ % ?status ?taxonomy ?slug],
@@ -339,16 +339,16 @@
               (:db/id child-page)))
   ;; RETRACT child-page
   ;; !!! BE CAREFUL WITH THIS !!!
-  (store/transact
-    (store/connection @app)
+  (db/transact
+    (db/connection @app)
     [[:db/retractEntity 66]])
 
-  (store/installed? $config)
-  (store/migration-keys (store/database $req))
-  (store/migration-ran? (store/database $req) schema/migrations)
-  (store/migration-ran? (store/database $req) schema/posts)
-  (store/migration-ran? (store/database $req) schema/i18n)
-  (store/migration-ran? (store/database $req) [{:migration/key :x}])
+  (db/installed? $config)
+  (db/migration-keys (db/database $req))
+  (db/migration-ran? (db/database $req) schema/migrations)
+  (db/migration-ran? (db/database $req) schema/posts)
+  (db/migration-ran? (db/database $req) schema/i18n)
+  (db/migration-ran? (db/database $req) [{:migration/key :x}])
 
   ;; Site-wide string in the requested lang
   (i18n/strings $req)

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -14,7 +14,7 @@
     [kaocha.repl :as k]
     [systems.bread.alpha.defaults :as defaults]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.plugin.datahike :as dh]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.plugin.reitit]

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -288,7 +288,7 @@
     (select-keys $ [:status :body :headers]))
 
   (defn q [query & args]
-    (apply store/q (store/datastore $req) query args))
+    (apply store/q (store/database $req) query args))
 
   (q '{:find [(pull ?e [:db/id :post/slug])],
        :in [$ % ?status ?taxonomy ?slug],
@@ -344,11 +344,11 @@
     [[:db/retractEntity 66]])
 
   (store/installed? $config)
-  (store/migration-keys (store/datastore $req))
-  (store/migration-ran? (store/datastore $req) schema/migrations)
-  (store/migration-ran? (store/datastore $req) schema/posts)
-  (store/migration-ran? (store/datastore $req) schema/i18n)
-  (store/migration-ran? (store/datastore $req) [{:migration/key :x}])
+  (store/migration-keys (store/database $req))
+  (store/migration-ran? (store/database $req) schema/migrations)
+  (store/migration-ran? (store/database $req) schema/posts)
+  (store/migration-ran? (store/database $req) schema/i18n)
+  (store/migration-ran? (store/database $req) [{:migration/key :x}])
 
   ;; Site-wide string in the requested lang
   (i18n/strings $req)

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -149,7 +149,7 @@
   :stop (when (:reinstall-db? env)
           (println "DELETING DEV DATABASE.")
           (try
-            (store/delete-database! $config)
+            (store/delete! $config)
             (catch clojure.lang.ExceptionInfo e
               (println (format "Error deleting database on stop: %s"
                                (ex-message e)))

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -141,7 +141,7 @@
   :start (when (:reinstall-db? env)
            (println "REINSTALLING DATABASE.")
            (try
-             (store/install! $config {:force? true})
+             (store/create! $config {:force? true})
              (catch clojure.lang.ExceptionInfo e
                (println (format "Error reinstalling database: %s"
                                 (ex-message e)))

--- a/dev/breadbox/app.clj
+++ b/dev/breadbox/app.clj
@@ -169,7 +169,7 @@
   :start (reset! app
                  (bread/load-app
                    (defaults/app
-                     {:datastore $config
+                     {:db $config
                       :routes {:router $router}
                       :i18n {:supported-langs #{:en :fr}}
                       :navigation

--- a/dev/cgi.edn
+++ b/dev/cgi.edn
@@ -1,5 +1,5 @@
 {:bread/handler #ig/ref :bread/app
- :bread/app {:datastore false
+ :bread/app {:db false
              :i18n false
              :routes
              {:router #ig/ref :bread/router}

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -6,7 +6,7 @@
                       [:security :anti-forgery] false}
  :ring/session-store
  {:store/type :datalog
-  :store/datastore #ig/ref :bread/db}
+  :store/db #ig/ref :bread/db}
  :bread/handler #ig/ref :bread/app
  :bread/app
  {:db #ig/ref :bread/db

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -9,20 +9,20 @@
   :store/datastore #ig/ref :bread/datastore}
  :bread/handler #ig/ref :bread/app
  :bread/app
- {:datastore #ig/ref :bread/datastore
+ {:db #ig/ref :bread/datastore
   :auth {:lock-seconds 10}
   :i18n true
   :routes {:router #ig/ref :bread/router}
   :components {:not-found #var systems.bread.alpha.cms.main/not-found}
   :plugins []}
  :bread/datastore
- {:datastore/type :datahike
+ {:db/type :datahike
   :store {:backend :mem
           :id "bread-db"}
   :recreate? true
   :force? true
-  :datastore/migrations #deref #var systems.bread.alpha.schema/initial
-  :datastore/initial-txns
+  :db/migrations #deref #var systems.bread.alpha.schema/initial
+  :db/initial-txns
   #concat [#deref #var systems.bread.alpha.cms.defaults/initial-data
            [{:user/username "coby"
              :user/name "Coby Tamayo"

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -6,16 +6,16 @@
                       [:security :anti-forgery] false}
  :ring/session-store
  {:store/type :datalog
-  :store/datastore #ig/ref :bread/datastore}
+  :store/datastore #ig/ref :bread/db}
  :bread/handler #ig/ref :bread/app
  :bread/app
- {:db #ig/ref :bread/datastore
+ {:db #ig/ref :bread/db
   :auth {:lock-seconds 10}
   :i18n true
   :routes {:router #ig/ref :bread/router}
   :components {:not-found #var systems.bread.alpha.cms.main/not-found}
   :plugins []}
- :bread/datastore
+ :bread/db
  {:db/type :datahike
   :store {:backend :mem
           :id "bread-db"}

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -6,7 +6,7 @@
     [clojure.edn :as edn]
     [systems.bread.alpha.component :as component :refer [defc]]
     [systems.bread.alpha.dispatcher :as dispatcher]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.internal.time :as t]
     [ring.middleware.session.store :as ss :refer [SessionStore]])

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -229,7 +229,7 @@
        [{:query/name ::store/query
          :query/key :auth/result
          :query/description "Find a user with the given username"
-         :query/db (store/datastore req)
+         :query/db (store/database req)
          :query/args
          ['{:find [(pull ?e [:db/id
                              :user/username

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -6,7 +6,7 @@
     [clojure.edn :as edn]
     [systems.bread.alpha.component :as component :refer [defc]]
     [systems.bread.alpha.dispatcher :as dispatcher]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.internal.time :as t]
     [ring.middleware.session.store :as ss :refer [SessionStore]])
@@ -20,12 +20,12 @@
   SessionStore
   (ss/delete-session [_ sk]
     (let [sk (->uuid sk)]
-      (store/transact conn [[:db/retract [:session/uuid sk] :session/uuid]
+      (db/transact conn [[:db/retract [:session/uuid sk] :session/uuid]
                             [:db/retract [:session/uuid sk] :session/data]])
       sk))
   (ss/read-session [_ sk]
     (let [sk (->uuid sk)
-          data (store/q @conn
+          data (db/q @conn
                         '{:find [?data .]
                           :in [$ ?sk]
                           :where [[?e :session/data ?data]
@@ -34,7 +34,7 @@
       (edn/read-string data)))
   (ss/write-session [_ sk data]
     (let [sk (or (->uuid sk) (UUID/randomUUID))]
-      (store/transact conn [{:session/uuid sk :session/data (pr-str data)}])
+      (db/transact conn [{:session/uuid sk :session/data (pr-str data)}])
       sk)))
 
 (defn session-store [conn]
@@ -176,23 +176,23 @@
 
       ;; User successfully logged in; reset count.
       (and valid (= :logged-in (:auth/step result)))
-      (store/transact conn [(assoc transaction
-                                   :user/failed-login-count 0)])
+      (db/transact conn [(assoc transaction
+                                :user/failed-login-count 0)])
 
       (and (:user/locked-at user)
            (account-locked? (t/now) (:user/locked-at user) lock-seconds))
       nil
 
       (>= (:user/failed-login-count user) max-failed-login-count)
-      (store/transact conn [(assoc transaction
-                                   ;; Lock account, but reset attempts.
-                                   :user/locked-at (t/now)
-                                   :user/failed-login-count 0)])
+      (db/transact conn [(assoc transaction
+                                ;; Lock account, but reset attempts.
+                                :user/locked-at (t/now)
+                                :user/failed-login-count 0)])
 
       :default
       (let [incremented (inc (:user/failed-login-count user))]
-        (store/transact conn [(assoc transaction
-                                     :user/failed-login-count incremented)])))))
+        (db/transact conn [(assoc transaction
+                                  :user/failed-login-count incremented)])))))
 
 (defmethod dispatcher/dispatch ::login
   [{:keys [params request-method session] :as req}]
@@ -226,10 +226,10 @@
       ;; Login
       post?
       {:queries
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :auth/result
          :query/description "Find a user with the given username"
-         :query/db (store/database req)
+         :query/db (db/database req)
          :query/args
          ['{:find [(pull ?e [:db/id
                              :user/username
@@ -251,7 +251,7 @@
          "Record this login attempt, locking account after too many."
          ;; Get :user from data, since it may not be in session data yet.
          :max-failed-login-count max-failed-login-count
-         :conn (store/connection req)}]
+         :conn (db/connection req)}]
        :hooks
        {::bread/expand
         [{:action/name ::set-session

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -222,7 +222,7 @@
 ;; TransactionalDatastoreConnection protocols
 ;;
 
-(defmethod store/connect! :datahike [config]
+(defmethod store/connect :datahike [config]
   (try
     (d/connect config)
     (catch IllegalArgumentException e
@@ -233,7 +233,7 @@
                        :message   (.getMessage e)
                        :config    config})))))
 
-(defmethod store/create-database! :datahike [config & [{:keys [force?]}]]
+(defmethod store/create! :datahike [config & [{:keys [force?]}]]
   (try
     (d/create-database config)
     (catch clojure.lang.ExceptionInfo e
@@ -244,9 +244,9 @@
 
 ;; TODO rm?
 (defmethod store/install! :datahike [config & [{:keys [force?]}]]
-  (store/create-database! config {:force? force?}))
+  (store/create! config {:force? force?}))
 
-(defmethod store/delete-database! :datahike [config]
+(defmethod store/delete! :datahike [config]
   (d/delete-database config))
 
 (defmethod store/max-tx :datahike [req]

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -28,16 +28,16 @@
 
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
    ;;                           ;;
-  ;;    Datastore Protocols    ;;
+  ;;     Database Protocols    ;;
  ;;                           ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;
-;; Implement Bread's core TemporalDatastore and
-;; TransactionalDatastoreConnection protocols
+;; Implement Bread's core TemporalDatabase and
+;; TransactionalDatabaseConnection protocols
 ;;
 
-(extend-protocol store/TemporalDatastore
+(extend-protocol store/TemporalDatabase
   datahike.db.DB
   (as-of [store instant]
     (d/as-of store instant))
@@ -166,7 +166,7 @@
      (d/q query store a b c d e f g h i j k l m n o p r))))
 
 
-(extend-protocol store/TransactionalDatastoreConnection
+(extend-protocol store/TransactionalDatabaseConnection
   clojure.lang.Atom
   (db [conn] (deref conn))
   (transact [conn tx]
@@ -218,8 +218,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;
-;; Implement Bread's core TemporalDatastore and
-;; TransactionalDatastoreConnection protocols
+;; Implement Bread's core TemporalDatabase and
+;; TransactionalDatabaseConnection protocols
 ;;
 
 (defmethod store/connect :datahike [config]

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -242,10 +242,6 @@
           (d/delete-database config)
           (d/create-database config))))))
 
-;; TODO rm?
-(defmethod store/install! :datahike [config & [{:keys [force?]}]]
-  (store/create! config {:force? force?}))
-
 (defmethod store/delete! :datahike [config]
   (d/delete-database config))
 

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -3,7 +3,7 @@
   (:require
     [clojure.core.protocols :refer [Datafiable]]
     [datahike.api :as d]
-    [datahike.db :as db]
+    [datahike.db :as dhdb]
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.datastore :as store])
@@ -177,8 +177,8 @@
   Datafiable
   (datafy [db]
     {:type 'datahike.db.AsOfDB
-     :max-tx (db/-max-tx db)
-     :max-eid (db/-max-eid db)}))
+     :max-tx (dhdb/-max-tx db)
+     :max-eid (dhdb/-max-eid db)}))
 
 (extend-type datahike.db.DB
   Datafiable

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -252,7 +252,7 @@
   "Takes a request and returns a datastore instance, optionally configured
    as a temporal-db (via as-of) or with-db (via db-with)"
   [req]
-  (let [conn (bread/config req :datastore/connection)
+  (let [conn (bread/config req :db/connection)
         timepoint (store/timepoint req)]
     (if timepoint
       (with-meta
@@ -269,5 +269,5 @@
                     :max-eid (:max-eid db)})}))))
 
 (defmethod store/plugin :datahike [config]
-  (let [config (merge {:datastore/req->datastore datastore} config)]
+  (let [config (merge {:db/req->datastore datastore} config)]
     (store/base-plugin config)))

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -6,7 +6,7 @@
     [datahike.db :as dhdb]
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store])
+    [systems.bread.alpha.database :as db])
   (:import
     [java.lang IllegalArgumentException]
     [java.util UUID]))
@@ -37,136 +37,136 @@
 ;; TransactionalDatabaseConnection protocols
 ;;
 
-(extend-protocol store/TemporalDatabase
+(extend-protocol db/TemporalDatabase
   datahike.db.DB
-  (as-of [store instant]
-    (d/as-of store instant))
-  (history [store]
-    (d/history store))
+  (as-of [db instant]
+    (d/as-of db instant))
+  (history [db]
+    (d/history db))
   (q
-    ([store query]
-     (d/q query store))
-    ([store query a]
-     (d/q query store a))
-    ([store query a b]
-     (d/q query store a b))
-    ([store query a b c]
-     (d/q query store a b c))
-    ([store query a b c d]
-     (d/q query store a b c d))
-    ([store query a b c d e]
-     (d/q query store a b c d e))
-    ([store query a b c d e f]
-     (d/q query store a b c d e f))
-    ([store query a b c d e f g]
-     (d/q query store a b c d e f g))
-    ([store query a b c d e f g h]
-     (d/q query store a b c d e f g h))
-    ([store query a b c d e f g h i]
-     (d/q query store a b c d e f g h i))
-    ([store query a b c d e f g h i j]
-     (d/q query store a b c d e f g h i j))
-    ([store query a b c d e f g h i j k]
-     (d/q query store a b c d e f g h i j k))
-    ([store query a b c d e f g h i j k l]
-     (d/q query store a b c d e f g h i j k l))
-    ([store query a b c d e f g h i j k l m]
-     (d/q query store a b c d e f g h i j k l m))
-    ([store query a b c d e f g h i j k l m n]
-     (d/q query store a b c d e f g h i j k l m n))
-    ([store query a b c d e f g h i j k l m n o]
-     (d/q query store a b c d e f g h i j k l m n o))
-    ([store query a b c d e f g h i j k l m n o p]
-     (d/q query store a b c d e f g h i j k l m n o p))
-    ([store query a b c d e f g h i j k l m n o p r]
-     (d/q query store a b c d e f g h i j k l m n o p r)))
-  (pull [store query ident]
-    (d/pull store query ident))
-  (db-with [store tx]
-    (d/db-with store tx))
+    ([db query]
+     (d/q query db))
+    ([db query a]
+     (d/q query db a))
+    ([db query a b]
+     (d/q query db a b))
+    ([db query a b c]
+     (d/q query db a b c))
+    ([db query a b c d]
+     (d/q query db a b c d))
+    ([db query a b c d e]
+     (d/q query db a b c d e))
+    ([db query a b c d e f]
+     (d/q query db a b c d e f))
+    ([db query a b c d e f g]
+     (d/q query db a b c d e f g))
+    ([db query a b c d e f g h]
+     (d/q query db a b c d e f g h))
+    ([db query a b c d e f g h i]
+     (d/q query db a b c d e f g h i))
+    ([db query a b c d e f g h i j]
+     (d/q query db a b c d e f g h i j))
+    ([db query a b c d e f g h i j k]
+     (d/q query db a b c d e f g h i j k))
+    ([db query a b c d e f g h i j k l]
+     (d/q query db a b c d e f g h i j k l))
+    ([db query a b c d e f g h i j k l m]
+     (d/q query db a b c d e f g h i j k l m))
+    ([db query a b c d e f g h i j k l m n]
+     (d/q query db a b c d e f g h i j k l m n))
+    ([db query a b c d e f g h i j k l m n o]
+     (d/q query db a b c d e f g h i j k l m n o))
+    ([db query a b c d e f g h i j k l m n o p]
+     (d/q query db a b c d e f g h i j k l m n o p))
+    ([db query a b c d e f g h i j k l m n o p r]
+     (d/q query db a b c d e f g h i j k l m n o p r)))
+  (pull [db query ident]
+    (d/pull db query ident))
+  (db-with [db tx]
+    (d/db-with db tx))
 
   datahike.db.AsOfDB
   (q
-    ([store query]
-     (d/q query store))
-    ([store query a]
-     (d/q query store a))
-    ([store query a b]
-     (d/q query store a b))
-    ([store query a b c]
-     (d/q query store a b c))
-    ([store query a b c d]
-     (d/q query store a b c d))
-    ([store query a b c d e]
-     (d/q query store a b c d e))
-    ([store query a b c d e f]
-     (d/q query store a b c d e f))
-    ([store query a b c d e f g]
-     (d/q query store a b c d e f g))
-    ([store query a b c d e f g h]
-     (d/q query store a b c d e f g h))
-    ([store query a b c d e f g h i]
-     (d/q query store a b c d e f g h i))
-    ([store query a b c d e f g h i j]
-     (d/q query store a b c d e f g h i j))
-    ([store query a b c d e f g h i j k]
-     (d/q query store a b c d e f g h i j k))
-    ([store query a b c d e f g h i j k l]
-     (d/q query store a b c d e f g h i j k l))
-    ([store query a b c d e f g h i j k l m]
-     (d/q query store a b c d e f g h i j k l m))
-    ([store query a b c d e f g h i j k l m n]
-     (d/q query store a b c d e f g h i j k l m n))
-    ([store query a b c d e f g h i j k l m n o]
-     (d/q query store a b c d e f g h i j k l m n o))
-    ([store query a b c d e f g h i j k l m n o p]
-     (d/q query store a b c d e f g h i j k l m n o p))
-    ([store query a b c d e f g h i j k l m n o p r]
-     (d/q query store a b c d e f g h i j k l m n o p r)))
-  (pull [store query ident]
-    (d/pull store query ident))
+    ([db query]
+     (d/q query db))
+    ([db query a]
+     (d/q query db a))
+    ([db query a b]
+     (d/q query db a b))
+    ([db query a b c]
+     (d/q query db a b c))
+    ([db query a b c d]
+     (d/q query db a b c d))
+    ([db query a b c d e]
+     (d/q query db a b c d e))
+    ([db query a b c d e f]
+     (d/q query db a b c d e f))
+    ([db query a b c d e f g]
+     (d/q query db a b c d e f g))
+    ([db query a b c d e f g h]
+     (d/q query db a b c d e f g h))
+    ([db query a b c d e f g h i]
+     (d/q query db a b c d e f g h i))
+    ([db query a b c d e f g h i j]
+     (d/q query db a b c d e f g h i j))
+    ([db query a b c d e f g h i j k]
+     (d/q query db a b c d e f g h i j k))
+    ([db query a b c d e f g h i j k l]
+     (d/q query db a b c d e f g h i j k l))
+    ([db query a b c d e f g h i j k l m]
+     (d/q query db a b c d e f g h i j k l m))
+    ([db query a b c d e f g h i j k l m n]
+     (d/q query db a b c d e f g h i j k l m n))
+    ([db query a b c d e f g h i j k l m n o]
+     (d/q query db a b c d e f g h i j k l m n o))
+    ([db query a b c d e f g h i j k l m n o p]
+     (d/q query db a b c d e f g h i j k l m n o p))
+    ([db query a b c d e f g h i j k l m n o p r]
+     (d/q query db a b c d e f g h i j k l m n o p r)))
+  (pull [db query ident]
+    (d/pull db query ident))
 
   datahike.db.HistoricalDB
   (q
-    ([store query]
-     (d/q query store))
-    ([store query a]
-     (d/q query store a))
-    ([store query a b]
-     (d/q query store a b))
-    ([store query a b c]
-     (d/q query store a b c))
-    ([store query a b c d]
-     (d/q query store a b c d))
-    ([store query a b c d e]
-     (d/q query store a b c d e))
-    ([store query a b c d e f]
-     (d/q query store a b c d e f))
-    ([store query a b c d e f g]
-     (d/q query store a b c d e f g))
-    ([store query a b c d e f g h]
-     (d/q query store a b c d e f g h))
-    ([store query a b c d e f g h i]
-     (d/q query store a b c d e f g h i))
-    ([store query a b c d e f g h i j]
-     (d/q query store a b c d e f g h i j))
-    ([store query a b c d e f g h i j k]
-     (d/q query store a b c d e f g h i j k))
-    ([store query a b c d e f g h i j k l]
-     (d/q query store a b c d e f g h i j k l))
-    ([store query a b c d e f g h i j k l m]
-     (d/q query store a b c d e f g h i j k l m))
-    ([store query a b c d e f g h i j k l m n]
-     (d/q query store a b c d e f g h i j k l m n))
-    ([store query a b c d e f g h i j k l m n o]
-     (d/q query store a b c d e f g h i j k l m n o))
-    ([store query a b c d e f g h i j k l m n o p]
-     (d/q query store a b c d e f g h i j k l m n o p))
-    ([store query a b c d e f g h i j k l m n o p r]
-     (d/q query store a b c d e f g h i j k l m n o p r))))
+    ([db query]
+     (d/q query db))
+    ([db query a]
+     (d/q query db a))
+    ([db query a b]
+     (d/q query db a b))
+    ([db query a b c]
+     (d/q query db a b c))
+    ([db query a b c d]
+     (d/q query db a b c d))
+    ([db query a b c d e]
+     (d/q query db a b c d e))
+    ([db query a b c d e f]
+     (d/q query db a b c d e f))
+    ([db query a b c d e f g]
+     (d/q query db a b c d e f g))
+    ([db query a b c d e f g h]
+     (d/q query db a b c d e f g h))
+    ([db query a b c d e f g h i]
+     (d/q query db a b c d e f g h i))
+    ([db query a b c d e f g h i j]
+     (d/q query db a b c d e f g h i j))
+    ([db query a b c d e f g h i j k]
+     (d/q query db a b c d e f g h i j k))
+    ([db query a b c d e f g h i j k l]
+     (d/q query db a b c d e f g h i j k l))
+    ([db query a b c d e f g h i j k l m]
+     (d/q query db a b c d e f g h i j k l m))
+    ([db query a b c d e f g h i j k l m n]
+     (d/q query db a b c d e f g h i j k l m n))
+    ([db query a b c d e f g h i j k l m n o]
+     (d/q query db a b c d e f g h i j k l m n o))
+    ([db query a b c d e f g h i j k l m n o p]
+     (d/q query db a b c d e f g h i j k l m n o p))
+    ([db query a b c d e f g h i j k l m n o p r]
+     (d/q query db a b c d e f g h i j k l m n o p r))))
 
 
-(extend-protocol store/TransactionalDatabaseConnection
+(extend-protocol db/TransactionalDatabaseConnection
   clojure.lang.Atom
   (db [conn] (deref conn))
   (transact [conn tx]
@@ -200,7 +200,7 @@
 ;; Methods for managing database connection and state.
 ;;
 
-(defmethod store/connect :datahike [config]
+(defmethod db/connect :datahike [config]
   (try
     (d/connect config)
     (catch IllegalArgumentException e
@@ -211,7 +211,7 @@
                        :message   (.getMessage e)
                        :config    config})))))
 
-(defmethod store/create! :datahike [config & [{:keys [force?]}]]
+(defmethod db/create! :datahike [config & [{:keys [force?]}]]
   (try
     (d/create-database config)
     (catch clojure.lang.ExceptionInfo e
@@ -220,8 +220,8 @@
           (d/delete-database config)
           (d/create-database config))))))
 
-(defmethod store/delete! :datahike [config]
+(defmethod db/delete! :datahike [config]
   (d/delete-database config))
 
-(defmethod store/max-tx :datahike [req]
-  (:max-tx (store/database req)))
+(defmethod db/max-tx :datahike [req]
+  (:max-tx (db/database req)))

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -6,7 +6,7 @@
     [datahike.db :as dhdb]
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store])
+    [systems.bread.alpha.database :as store])
   (:import
     [java.lang IllegalArgumentException]
     [java.util UUID]))

--- a/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
+++ b/plugins/datahike/systems/bread/alpha/plugin/datahike.cljc
@@ -224,4 +224,4 @@
   (d/delete-database config))
 
 (defmethod store/max-tx :datahike [req]
-  (:max-tx (store/datastore req)))
+  (:max-tx (store/database req)))

--- a/plugins/markdown/systems/bread/alpha/plugin/markdown.cljc
+++ b/plugins/markdown/systems/bread/alpha/plugin/markdown.cljc
@@ -1,5 +1,5 @@
 ;; Utilities for reading content from the filesystem
-;; rather than from the datastore.
+;; rather than from the database.
 (ns systems.bread.alpha.plugin.markdown
   (:require
     [clojure.instant :as instant]

--- a/src/systems/bread/alpha/database.cljc
+++ b/src/systems/bread/alpha/database.cljc
@@ -56,7 +56,7 @@
       (bread/hook ::connection)))
 
 (defn datastore [app]
-  (bread/hook app :hook/datastore))
+  (bread/hook app ::db))
 
 (defn db-datetime
   "Returns the as-of database instant (DateTime) for the given request,
@@ -82,7 +82,7 @@
                     nil)))))
 
 (defn timepoint [req]
-  (bread/hook req :hook/datastore.req->timepoint))
+  (bread/hook req ::timepoint))
 
 (defmethod bread/effect ::transact
   [{:keys [conn txs]} _]
@@ -212,7 +212,7 @@
        {::bread/init
         [{:action/name ::migrate :migrations migrations}
          {:action/name ::transact-initial :txs initial-txns}]
-        :hook/datastore.req->timepoint
+        ::timepoint
         [{:action/name ::timepoint :req->timepoint req->timepoint}]
-        :hook/datastore
+        ::db
         [{:action/name ::db :req->datastore req->datastore}]}})))

--- a/src/systems/bread/alpha/database.cljc
+++ b/src/systems/bread/alpha/database.cljc
@@ -13,29 +13,29 @@
                    (:db/type (bread/config app :db/config))))
 
 (defprotocol TemporalDatabase
-  (as-of [store timepoint])
-  (history [store])
-  (pull [store struct lookup-ref])
-  (q [store query]
-     [store query a]
-     [store query a b]
-     [store query a b c]
-     [store query a b c d]
-     [store query a b c d e]
-     [store query a b c d e f]
-     [store query a b c d e f g]
-     [store query a b c d e f g h]
-     [store query a b c d e f g h i]
-     [store query a b c d e f g h i j]
-     [store query a b c d e f g h i j k]
-     [store query a b c d e f g h i j k l]
-     [store query a b c d e f g h i j k l m]
-     [store query a b c d e f g h i j k l m n]
-     [store query a b c d e f g h i j k l m n o]
-     [store query a b c d e f g h i j k l m n o p]
-     [store query a b c d e f g h i j k l m n o p q]
-     [store query a b c d e f g h i j k l m n o p q r])
-  (db-with [store timepoint]))
+  (as-of [db timepoint])
+  (history [db])
+  (pull [db struct lookup-ref])
+  (q [db query]
+     [db query a]
+     [db query a b]
+     [db query a b c]
+     [db query a b c d]
+     [db query a b c d e]
+     [db query a b c d e f]
+     [db query a b c d e f g]
+     [db query a b c d e f g h]
+     [db query a b c d e f g h i]
+     [db query a b c d e f g h i j]
+     [db query a b c d e f g h i j k]
+     [db query a b c d e f g h i j k l]
+     [db query a b c d e f g h i j k l m]
+     [db query a b c d e f g h i j k l m n]
+     [db query a b c d e f g h i j k l m n o]
+     [db query a b c d e f g h i j k l m n o p]
+     [db query a b c d e f g h i j k l m n o p q]
+     [db query a b c d e f g h i j k l m n o p q r])
+  (db-with [db timepoint]))
 
 (defmethod connect :default [{:db/keys [type] :as config}]
   (let [msg (if (nil? type)
@@ -162,7 +162,7 @@
 
 (defn plugin
   "Helper for instantiating a database. Do not call this fn directly from
-  application code; recommended for use from plugins only. Use store/plugin
+  application code; recommended for use from plugins only. Use db/plugin
   instead."
   [config]
   ;; TODO make these simple keys

--- a/src/systems/bread/alpha/database.cljc
+++ b/src/systems/bread/alpha/database.cljc
@@ -1,4 +1,4 @@
-(ns systems.bread.alpha.datastore
+(ns systems.bread.alpha.database
   (:require
     [clojure.core.protocols :refer [datafy]]
     [clojure.spec.alpha :as spec]

--- a/src/systems/bread/alpha/database.cljc
+++ b/src/systems/bread/alpha/database.cljc
@@ -175,7 +175,7 @@
   [req {:keys [req->timepoint]} _]
   (req->timepoint req))
 
-(defmethod bread/action ::datastore
+(defmethod bread/action ::db
   [req {:keys [req->datastore]} _]
   (req->datastore req))
 
@@ -215,4 +215,4 @@
         :hook/datastore.req->timepoint
         [{:action/name ::timepoint :req->timepoint req->timepoint}]
         :hook/datastore
-        [{:action/name ::datastore :req->datastore req->datastore}]}})))
+        [{:action/name ::db :req->datastore req->datastore}]}})))

--- a/src/systems/bread/alpha/datastore.cljc
+++ b/src/systems/bread/alpha/datastore.cljc
@@ -9,13 +9,9 @@
 (defmulti create! (fn [config & _]
                              (:datastore/type config)))
 (defmulti delete! :datastore/type)
-(defmulti connection :datastore/type)
 (defmulti plugin :datastore/type)
 (defmulti max-tx (fn [app]
                    (:datastore/type (bread/config app :datastore/config))))
-
-(defmethod connection :default [app]
-  (bread/config app :datastore/connection))
 
 (defprotocol TemporalDatastore
   (as-of [store timepoint])
@@ -53,6 +49,11 @@
 (defprotocol TransactionalDatastoreConnection
   (db [conn])
   (transact [conn txs]))
+
+(defn connection [app]
+  (-> app
+      (bread/config :datastore/connection)
+      (bread/hook ::connection)))
 
 (defn datastore [app]
   (bread/hook app :hook/datastore))

--- a/src/systems/bread/alpha/datastore.cljc
+++ b/src/systems/bread/alpha/datastore.cljc
@@ -8,10 +8,6 @@
 (defmulti connect :datastore/type)
 (defmulti create! (fn [config & _]
                              (:datastore/type config)))
-;; TODO is this fn needed?
-(defmulti install! (fn [config & _]
-                     (:datastore/type config)))
-(defmulti installed? :datastore/type)
 (defmulti delete! :datastore/type)
 (defmulti connection :datastore/type)
 (defmulti plugin :datastore/type)
@@ -86,16 +82,6 @@
 
 (defn timepoint [req]
   (bread/hook req :hook/datastore.req->timepoint))
-
-(defmethod installed? :default [config]
-  (try
-    (let [db (-> config connect db)]
-      (set? (q db '[:find ?e :where [?e :db/ident]])))
-    (catch clojure.lang.ExceptionInfo e
-      (when-not (#{:db-does-not-exist :backend-does-not-exist}
-                  (:type (ex-data e)))
-        (throw e))
-      false)))
 
 (defmethod bread/effect ::transact
   [{:keys [conn txs]} _]

--- a/src/systems/bread/alpha/datastore.cljc
+++ b/src/systems/bread/alpha/datastore.cljc
@@ -13,7 +13,7 @@
 (defmulti max-tx (fn [app]
                    (:datastore/type (bread/config app :datastore/config))))
 
-(defprotocol TemporalDatastore
+(defprotocol TemporalDatabase
   (as-of [store timepoint])
   (history [store])
   (pull [store struct lookup-ref])
@@ -46,7 +46,7 @@
     (throw (ex-info msg {:config        config
                          :bread.context :datastore/connect}))))
 
-(defprotocol TransactionalDatastoreConnection
+(defprotocol TransactionalDatabaseConnection
   (db [conn])
   (transact [conn txs]))
 

--- a/src/systems/bread/alpha/dispatcher.cljc
+++ b/src/systems/bread/alpha/dispatcher.cljc
@@ -6,10 +6,10 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.route :as route]
-    [systems.bread.alpha.database :as store]))
+    [systems.bread.alpha.database :as db]))
 
 (defn query-key [dispatcher]
-  "Get from the component layer the key at which to store the dispatchd query
+  "Get from the component layer the key at which to db the dispatched query
   within the ::bread/queries map"
   (component/query-key (:dispatcher/component dispatcher)))
 

--- a/src/systems/bread/alpha/dispatcher.cljc
+++ b/src/systems/bread/alpha/dispatcher.cljc
@@ -6,7 +6,7 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.route :as route]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 (defn query-key [dispatcher]
   "Get from the component layer the key at which to store the dispatchd query

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -2,7 +2,7 @@
   (:require
     [clojure.edn :as edn]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.internal.query-inference :as inf]

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -2,7 +2,7 @@
   (:require
     [clojure.edn :as edn]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.internal.query-inference :as inf]
@@ -37,14 +37,14 @@
   ([req]
    (strings req (lang req)))
   ([req lang]
-   (->> (store/q (store/database req)
-                 '{:find [?key ?content]
-                   :in [$ ?lang]
-                   :where [[?e :field/key ?key]
-                           [?e :field/content ?content]
-                           [?e :field/lang ?lang]
-                           (not-join [?e] [_ :translatable/fields ?e])]}
-                 lang)
+   (->> (db/q (db/database req)
+              '{:find [?key ?content]
+                :in [$ ?lang]
+                :where [[?e :field/key ?key]
+                        [?e :field/content ?content]
+                        [?e :field/lang ?lang]
+                        (not-join [?e] [_ :translatable/fields ?e])]}
+              lang)
         (into {})
         (bread/hook req ::strings))))
 
@@ -76,7 +76,7 @@
         id-path (if (sequential? k)
                   (concat [::bread/data] k [:db/id])
                   [::bread/data k :db/id])]
-    {:query/name ::store/query
+    {:query/name ::db/query
      :query/db (:query/db orig-query)
      :query/key path
      :query/args
@@ -136,10 +136,10 @@
 
 (defmethod bread/action ::add-strings-query
   [req _ _]
-  (query/add req {:query/name ::store/query
+  (query/add req {:query/name ::db/query
                   :query/key :i18n
                   :query/into {}
-                  :query/db (store/database req)
+                  :query/db (db/database req)
                   :query/args
                   ['{:find [?key ?content]
                      :in [$ ?lang]

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -37,7 +37,7 @@
   ([req]
    (strings req (lang req)))
   ([req lang]
-   (->> (store/q (store/datastore req)
+   (->> (store/q (store/database req)
                  '{:find [?key ?content]
                    :in [$ ?lang]
                    :where [[?e :field/key ?key]
@@ -139,7 +139,7 @@
   (query/add req {:query/name ::store/query
                   :query/key :i18n
                   :query/into {}
-                  :query/db (store/datastore req)
+                  :query/db (store/database req)
                   :query/args
                   ['{:find [?key ?content]
                      :in [$ ?lang]

--- a/src/systems/bread/alpha/internal/route_cache.cljc
+++ b/src/systems/bread/alpha/internal/route_cache.cljc
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [systems.bread.alpha.component :as component]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.util.datalog :as datalog]))
 
 (defn- get-attr-via [entity [step & steps]]

--- a/src/systems/bread/alpha/internal/route_cache.cljc
+++ b/src/systems/bread/alpha/internal/route_cache.cljc
@@ -38,7 +38,7 @@
                    :where '[[?e]]}]
         ;; TODO can we express this in a more data-oriented way?
         (fn [req eid]
-          (let [entity (store/q (store/datastore req) query eid)]
+          (let [entity (store/q (store/database req) query eid)]
             (reduce (fn [m [param path]]
                       (let [attr (get-attr-via entity path)
                             attr (if (coll? attr) attr (set (list attr)))]
@@ -89,7 +89,7 @@
     (component/query $)
     (affecting-attrs $ mapping)
     (datoms-with-attrs $ tx)
-    (extrapolate-eid (store/datastore req) $)))
+    (extrapolate-eid (store/database req) $)))
 
 (defn- cart [colls]
   (if (empty? colls)

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -50,7 +50,7 @@
 (defn expand-post-ids [req tree]
   (let [results (some->> tree
                          (post-items-query req)
-                         (store/q (store/datastore req)))
+                         (store/q (store/database req)))
         by-id (->> results
                    (map (fn [[{id :db/id :as post}
                               {title :field/content}]]
@@ -105,7 +105,7 @@
                   :where '[[?e :menu/locations _]]}]
        (->> query
             (bread/hook req :hook/global-menus-query)
-            (store/q (store/datastore req))
+            (store/q (store/database req))
             (map (comp #(assoc % :type :location)
                        (partial format-menu req)
                        first))
@@ -134,7 +134,7 @@
                 :where [['?e :menu/locations location]]}
          menu (as-> query $
                 (bread/hook req :hook/location-menu-query $ location)
-                (store/q (store/datastore req) $)
+                (store/q (store/database req) $)
                 (format-menu req $)
                 (assoc $ :type :location))]
      (->> menu
@@ -177,7 +177,7 @@
          items
          (as-> query $
                (bread/hook req :hook/posts-menu-query $)
-               (store/q (store/datastore req) $ t statuses)
+               (store/q (store/database req) $ t statuses)
                (map first $)
                (walk-posts->items $)
                (expand-post-ids req $))]

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -7,7 +7,7 @@
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.route :as route]
-    [systems.bread.alpha.database :as store]))
+    [systems.bread.alpha.database :as db]))
 
 (defn- collect-item-ids [tree]
   (reduce (fn [ids node]
@@ -50,7 +50,7 @@
 (defn expand-post-ids [req tree]
   (let [results (some->> tree
                          (post-items-query req)
-                         (store/q (store/database req)))
+                         (db/q (db/database req)))
         by-id (->> results
                    (map (fn [[{id :db/id :as post}
                               {title :field/content}]]
@@ -105,7 +105,7 @@
                   :where '[[?e :menu/locations _]]}]
        (->> query
             (bread/hook req :hook/global-menus-query)
-            (store/q (store/database req))
+            (db/q (db/database req))
             (map (comp #(assoc % :type :location)
                        (partial format-menu req)
                        first))
@@ -134,7 +134,7 @@
                 :where [['?e :menu/locations location]]}
          menu (as-> query $
                 (bread/hook req :hook/location-menu-query $ location)
-                (store/q (store/database req) $)
+                (db/q (db/database req) $)
                 (format-menu req $)
                 (assoc $ :type :location))]
      (->> menu
@@ -177,7 +177,7 @@
          items
          (as-> query $
                (bread/hook req :hook/posts-menu-query $)
-               (store/q (store/database req) $ t statuses)
+               (db/q (db/database req) $ t statuses)
                (map first $)
                (walk-posts->items $)
                (expand-post-ids req $))]

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -7,7 +7,7 @@
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.route :as route]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 (defn- collect-item-ids [tree]
   (reduce (fn [ids node]

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -4,7 +4,7 @@
     [clojure.string :as string]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.util.datalog :refer [where pull-query]]))

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -4,7 +4,7 @@
     [clojure.string :as string]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.util.datalog :refer [where pull-query]]))
@@ -81,9 +81,9 @@
                     ['?status :post/status :post.status/published]]))
         query-key (or (:dispatcher/key dispatcher) :post)
         ;; TODO query description
-        page-query {:query/name ::store/query
+        page-query {:query/name ::db/query
                     :query/key query-key
-                    :query/db (store/database req)
+                    :query/db (db/database req)
                     :query/args page-args}
         ;; TODO move this to i18n
         queries (conj (bread/hook req ::i18n/queries [page-query])

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -83,7 +83,7 @@
         ;; TODO query description
         page-query {:query/name ::store/query
                     :query/key query-key
-                    :query/db (store/datastore req)
+                    :query/db (store/database req)
                     :query/args page-args}
         ;; TODO move this to i18n
         queries (conj (bread/hook req ::i18n/queries [page-query])

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [systems.bread.alpha.component :as component]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]))
+    [systems.bread.alpha.database :as db]))
 
 ;; TODO opts
 (defn path [req path route-name]

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [systems.bread.alpha.component :as component]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 ;; TODO opts
 (defn path [req path route-name]

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -18,6 +18,10 @@
       :db/doc "Ref to the migration in which a given attr was introduced"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/one}
+     {:db/ident :attr/label
+      :db/doc "Human-readable label for the database attr itself"
+      :db/valueType :db.type/string
+      :db/cardinality :db.cardinality/one}
      {:migration/key :bread.migration/migrations
       :migration/description
       "Minimal schema for safely performing future migrations."}]
@@ -33,21 +37,25 @@
       :migration/key :bread.migration/i18n
       :migration/description "Migration for global translation strings"}
      {:db/ident :field/key
+      :attr/label "Field Key"
       :db/doc "Unique-per-entity keyword for this field"
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.i18n"}
      {:db/ident :field/content
+      :attr/label "Field Content"
       :db/doc "Field content as an EDN string"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.i18n"}
      {:db/ident :field/lang
+      :attr/label "Field Language"
       :db/doc "Language this field is written in"
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.i18n"}
      {:db/ident :translatable/fields
+      :attr/label "Translatable Fields"
       :db/doc "The set of all translatable fields for a given entity (post, taxon, etc.)."
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
@@ -64,54 +72,64 @@
       :migration/key :bread.migration/users
       :migration/description  "Migration for users and roles schema"}
      {:db/ident :user/uuid
+      :attr/label "User UUID"
       :db/doc "Unique identifier. Distinct from the Datahike entity ID."
       :db/valueType :db.type/uuid
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/email
+      :attr/label "Email"
       :db/doc "User account email"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/many
       :db/unique :db.unique/value
       :attr/migration "migration.users"}
      {:db/ident :user/username
+      :attr/label "Username"
       :db/doc "Username they use to login"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :db/unique :db.unique/identity
       :attr/migration "migration.users"}
      {:db/ident :user/password
+      :attr/label "Password"
       :db/doc "User account password hash"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/two-factor-key
+      :attr/label "2FA key"
       :db/doc "User's 2FA secret key"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/locked-at
+      :attr/label "Account Locked-at Time"
       :db/doc "When the user's account was locked for security purposes (if at all)"
       :db/valueType :db.type/instant
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/failed-login-count
+      :attr/label "Failed Login Count"
       :db/doc "How many times in a row the user has attempted to login"
       :db/valueType :db.type/number
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/name
+      :attr/label "Full Name"
       :db/doc "User's name"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/lang
+      :attr/label "Preferred Language"
       :db/doc "The user's preferred language, as a keyword"
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :user/slug
+      :attr/label "User Slug"
       :db/doc "The user's slugified name for use in URLs"
       :db/valueType :db.type/string
       :db/unique :db.unique/value
@@ -120,21 +138,25 @@
 
      ;; Roles
      {:db/ident :user/roles
+      :attr/label "Roles"
       :db/doc "User roles. Used for mapping to abilities for authorization"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.users"}
      {:db/ident :role/key
+      :attr/label "Role Key"
       :db/doc "The machine-readable key for a role"
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
      {:db/ident :role/abilities
+      :attr/label "Role Abilities"
       :db/doc "All abilities assigned to a give role"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.users"}
      {:db/ident :ability/key
+      :attr/label "Ability Key"
       :db/doc "The keyword identifier for an ability (for role-based authorization)"
       :db/valueType :db.type/keyword
       :db/unique :db.unique/identity
@@ -143,17 +165,14 @@
 
      ;; Sessions
      {:db/ident :session/uuid
+      :attr/label "Session UUID"
       :db/doc "Session identifier."
       :db/valueType :db.type/uuid
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.users"}
-     {:db/ident :session/user
-      :db/doc "The user this session belongs to."
-      :db/valueType :db.type/ref
-      :db/cardinality :db.cardinality/one
-      :attr/migration "migration.users"}
      {:db/ident :session/data
+      :attr/label "Session Data"
       :db/doc "Arbitrary session data."
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
@@ -170,46 +189,54 @@
       :migration/key :bread.migration/posts
       :migration/description "Posts and fields"}
      {:db/ident :post/uuid
+      :attr/label "Post UUID"
       :db/doc "Unique identifier for the post. Distinct from the Datahike entity ID."
       :db/valueType :db.type/uuid
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}
      {:db/ident :post/slug
+      :attr/label "Post Slug"
       :db/doc "Route-unique slug, typically based on the post title"
       :db/valueType :db.type/string
       :db/index true
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}
      {:db/ident :post/type
+      :attr/label "Post Type"
       :db/doc "Post type"
       :db/valueType :db.type/keyword
       :db/index true
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}
      {:db/ident :post/children
+      :attr/label "Post Children"
       :db/doc "Entity IDs of child posts, if any"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.posts"}
      {:db/ident :post/status
+      :attr/label "Post Status"
       :db/doc "Post status, i.e. whether it is published, in review, drafting, etc."
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}
      {:db/ident :post/created-at
+      :attr/label "Post Creation Time"
       :db/doc "Date/time this post was created"
       :db/valueType :db.type/instant
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}
      {:db/ident :post/publish-date
-      :db/doc "Date/time this post is scheduled to go live"
+      :attr/label "Post Publish Date"
+      :db/doc "Date/time this post was/is scheduled to go live"
       :db/valueType :db.type/instant
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.posts"}
 
      ;; Authorship of posts
      {:db/ident :post/authors
+      :attr/label "Post Authors"
       :db/doc "Zero or more entity IDs of a Post's author(s)"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
@@ -228,27 +255,32 @@
       :migration/key :bread.migration/taxons
       :migration/description "Migration for taxons"}
      {:db/ident :post/taxons
+      :attr/label "Post Taxons"
       :db/doc "Zero or more entity IDs of a Post's taxons"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.taxons"}
      {:db/ident :taxon/children
+      :attr/label "Taxon Children"
       :db/doc "_is-a_ relations between taxon entities, forming a hierarchy"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.taxons"}
      {:db/ident :taxon/taxonomy
+      :attr/label "Taxonomy"
       :db/doc "The hierarchy of taxons in which this taxon lives, e.g. tags, categories, etc. Analogous to WordPress taxonomies."
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.taxons"}
      {:db/ident :taxon/uuid
+      :attr/label "Taxon UUID"
       :db/doc "Unique identifier for the taxon. Distinct from the Datahike entity ID."
       :db/valueType :db.type/uuid
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.taxons"}
      {:db/ident :taxon/slug
+      :attr/label "Taxon Slug"
       :db/doc "Route-unique slug, typically based on the taxon title."
       :db/valueType :db.type/string
       :db/index true
@@ -268,16 +300,19 @@
       :migration/key :bread.migration/revisions
       :migration/description "Revisions"}
      {:db/ident :revision/post-id
+      :attr/label "Revision Post ID"
       :db/doc "The entity ID of the Post being revised"
       :db/valueType :db.type/long
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.revisions"}
      {:db/ident :revision/note
+      :attr/label "Revition Note"
       :db/doc "A note about what was changed as part of this revision"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.revisions"}
      {:db/ident :revision/created-at
+      :attr/label "Revision Create-at Time"
       :db/doc "Date/time this revision was made"
       :db/valueType :db.type/instant
       :db/cardinality :db.cardinality/one
@@ -295,39 +330,46 @@
       :migration/key :bread.migration/menus
       :migration/description  "Menus"}
      {:db/ident :menu/uuid
+      :attr/label "Menu UUID"
       :db/doc "Universally unique identifier for the menu. Distinct from the Datahike entity ID."
       :db/valueType :db.type/uuid
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.menus"}
      {:db/ident :menu/locations
+      :attr/label "Menu Locations"
       :db/doc "Locations this menu is being used for."
       :db/valueType :db.type/keyword
       :db/unique :db.unique/value
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.menus"}
      {:db/ident :menu/key
+      :attr/label "Menu Key"
       :db/doc "Globally unique menu name."
       :db/valueType :db.type/keyword
       :db/unique :db.unique/value
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.menus"}
      {:db/ident :menu/items
-      :db/doc "Menu items."
+      :attr/label "Menu Items"
+      :db/doc "The set of items that appear in this Menu."
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
       :attr/migration "migration.menus"}
      {:db/ident :menu.item/entity
+      :attr/label "Menu Item Entity"
       :db/doc "DB entity this item references (if any)."
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.menus"}
      {:db/ident :menu.item/order
+      :attr/label "Menu Item Sort Order"
       :db/doc "Ordinal number in which this item appears in the menu."
       :db/valueType :db.type/number
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.menus"}
      {:db/ident :menu.item/children
+      :attr/label "Menu Item Children"
       :db/doc "Any child items of this item."
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/many
@@ -345,37 +387,45 @@
       :migration/key :bread.migration/comments
       :migration/description "Comments"}
      {:db/ident :comment/uuid
+      :attr/label "Comment UUID"
       :db/doc "Universally unique identifier for the comment. Distinct from the Datahike entity ID."
       :db/valueType :db.type/uuid
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.comments"}
      {:db/ident :comment/post-id
+      :attr/label "Comment Post ID"
       :db/doc "The entity ID of the Post that this comment refers to"
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.comments"}
      {:db/ident :comment/content
+      :attr/label "Comment Content"
       :db/doc "The text of the comment"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.comments"}
+     ;; TODO ???
      {:db/ident :comment/field-path
+      :attr/label "Comment Field Path"
       :db/doc "The (EDN-serialized) path of the specific Post field that this comment refers to, if any (as opposed to the Post itself as a whole)"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.comments"}
      {:db/ident :comment/created-at
+      :attr/label "Comment Creation Time"
       :db/doc "When this comment was written"
       :db/valueType :db.type/instant
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.comments"}
      {:db/ident :comment/status
+      :attr/label "Comment Status"
       :db/doc "The status of this comment (pending, approved, spam, etc.)"
       :db/valueType :db.type/keyword
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.comments"}
      {:db/ident :comment/replies
+      :attr/label "Comment Replies"
       :db/doc "Zero or more replies (comment entity IDs) to this comment. Order by :comment/created-at to build a comment thread."
       :db/valueType :db.type/ref
       :db/cardinality :db.cardinality/one

--- a/src/systems/bread/alpha/taxon.cljc
+++ b/src/systems/bread/alpha/taxon.cljc
@@ -5,7 +5,7 @@
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.dispatcher :as dispatcher]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.internal.query-inference :as i]))
 
 (defmethod bread/query ::compact

--- a/src/systems/bread/alpha/taxon.cljc
+++ b/src/systems/bread/alpha/taxon.cljc
@@ -49,7 +49,7 @@
          :or {post-type :post.type/page
               post-status :post.status/published}}
         dispatcher
-        db (store/datastore req)
+        db (store/database req)
         pull-spec (dispatcher/pull-spec dispatcher)
         taxon-query {:query/name ::store/query
                      :query/key k

--- a/src/systems/bread/alpha/taxon.cljc
+++ b/src/systems/bread/alpha/taxon.cljc
@@ -5,7 +5,7 @@
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.dispatcher :as dispatcher]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.internal.query-inference :as i]))
 
 (defmethod bread/query ::compact
@@ -26,7 +26,7 @@
 (defn- posts-query [t status taxon-query spec path]
   (let [pull (get spec (last path))
         pull (if (some #{:db/id} pull) pull (cons :db/id pull))]
-    {:query/name ::store/query
+    {:query/name ::db/query
      :query/key path
      :query/db (:query/db taxon-query)
      :query/args
@@ -49,9 +49,9 @@
          :or {post-type :post.type/page
               post-status :post.status/published}}
         dispatcher
-        db (store/database req)
+        db (db/database req)
         pull-spec (dispatcher/pull-spec dispatcher)
-        taxon-query {:query/name ::store/query
+        taxon-query {:query/name ::db/query
                      :query/key k
                      :query/db db
                      :query/args

--- a/src/systems/bread/alpha/util/datalog.cljc
+++ b/src/systems/bread/alpha/util/datalog.cljc
@@ -4,7 +4,7 @@
     [clojure.walk :as walk]
     [clojure.string :as string]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 ;; TODO replace with datalog-pull
 (defn empty-query []

--- a/src/systems/bread/alpha/util/datalog.cljc
+++ b/src/systems/bread/alpha/util/datalog.cljc
@@ -104,7 +104,7 @@
                                         [?e :db/valueType ?types]]} types))))
 
 (defn migrations
-  "All schema changes throughout the history of the given datastore"
+  "All schema changes throughout the history of the given database"
   [store]
   (->> (store/q store '{:find
                         [(pull ?e [:db/id :db/txInstant
@@ -125,7 +125,7 @@
        (sort-by :db/txInstant)))
 
 (defn latest-migration
-  "Get the latest migration performed on the given datastore"
+  "Get the latest migration performed on the given database"
   [store]
   (first (store/q
            store
@@ -136,11 +136,11 @@
 
 (comment
 
-  ;; Do some minimal setup to get an example datastore instance.
+  ;; Do some minimal setup to get an example database instance.
   (do
     (require '[clojure.repl :as repl]
              '[breadbox.app :as breadbox :refer [app]])
-    (def $store (store/datastore @app)))
+    (def $store (store/database @app)))
 
   (migrations $store)
   (map (fn [migration]

--- a/src/systems/bread/alpha/util/datalog.cljc
+++ b/src/systems/bread/alpha/util/datalog.cljc
@@ -4,7 +4,7 @@
     [clojure.walk :as walk]
     [clojure.string :as string]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]))
+    [systems.bread.alpha.database :as db]))
 
 ;; TODO replace with datalog-pull
 (defn empty-query []
@@ -55,70 +55,70 @@
   (attr-binding :post/fields {:post/fields '[*]}))
 
 (defn attrs
-  "Get all schema data available about every attr present in store"
-  [store]
-  (map first (store/q store '{:find [(pull ?e [*])]
-                              :where [[?e :db/ident _]]})))
+  "Get all schema data available about every attr present in db"
+  [db]
+  (map first (db/q db '{:find [(pull ?e [*])]
+                        :where [[?e :db/ident _]]})))
 
 (defn attr
   "Get all schema data available about attr itself"
-  [store attr]
-  (store/q store '{:find [(pull ?e [*]) .]
-                   :in [$ ?attr]
-                   :where [[?e :db/ident ?attr]]} attr))
+  [db attr]
+  (db/q db '{:find [(pull ?e [*]) .]
+             :in [$ ?attr]
+             :where [[?e :db/ident ?attr]]} attr))
 
 (defn doc
   "Get the :db/doc string (if any) of attr"
-  [store attr]
-  (first (store/q store '{:find [[?doc]]
-                          :in [$ ?attr]
-                          :where [[?e :db/ident ?attr]
-                                  [?e :db/doc ?doc]]} attr)))
+  [db attr]
+  (first (db/q db '{:find [[?doc]]
+                    :in [$ ?attr]
+                    :where [[?e :db/ident ?attr]
+                            [?e :db/doc ?doc]]} attr)))
 
-(defn cardinality [store attr]
-  (first (store/q store '{:find [[?card]]
-                          :in [$ ?attr]
-                          :where [[?e :db/ident ?attr]
-                                  [?e :db/cardinality ?card]]} attr)))
+(defn cardinality [db attr]
+  (first (db/q db '{:find [[?card]]
+                    :in [$ ?attr]
+                    :where [[?e :db/ident ?attr]
+                            [?e :db/cardinality ?card]]} attr)))
 
-(defn cardinality-one? [store attr]
-  (= :db.cardinality/one (cardinality store attr)))
+(defn cardinality-one? [db attr]
+  (= :db.cardinality/one (cardinality db attr)))
 
-(defn cardinality-many? [store attr]
-  (= :db.cardinality/many (cardinality store attr)))
+(defn cardinality-many? [db attr]
+  (= :db.cardinality/many (cardinality db attr)))
 
-(defn value-type [store attr]
-  (first (store/q store '{:find [[?type]]
-                          :in [$ ?attr]
-                          :where [[?e :db/ident ?attr]
-                                  [?e :db/valueType ?type]]} attr)))
+(defn value-type [db attr]
+  (first (db/q db '{:find [[?type]]
+                    :in [$ ?attr]
+                    :where [[?e :db/ident ?attr]
+                            [?e :db/valueType ?type]]} attr)))
 
-(defn ref? [store attr]
-  (= :db.type/ref (value-type store attr)))
+(defn ref? [db attr]
+  (= :db.type/ref (value-type db attr)))
 
-(defn attrs-by-type [store types]
+(defn attrs-by-type [db types]
   (let [types (if (coll? types) types #{types})]
-    (map first (store/q store '{:find [?attr]
-                                :in [$ [?types ...]]
-                                :where [[?e :db/ident ?attr]
-                                        [?e :db/valueType ?types]]} types))))
+    (map first (db/q db '{:find [?attr]
+                          :in [$ [?types ...]]
+                          :where [[?e :db/ident ?attr]
+                                  [?e :db/valueType ?types]]} types))))
 
 (defn migrations
   "All schema changes throughout the history of the given database"
-  [store]
-  (->> (store/q store '{:find
-                        [(pull ?e [:db/id :db/txInstant
-                                   :migration/key :migration/description])]
-                        :where [[?e :migration/key _]]})
+  [db]
+  (->> (db/q db '{:find
+                  [(pull ?e [:db/id :db/txInstant
+                             :migration/key :migration/description])]
+                  :where [[?e :migration/key _]]})
        (map (fn [[{id :db/id :as migration}]]
               (let [attrs
-                    (store/q store '{:find
-                                     [(pull ?e [:db/ident :db/doc
-                                                :db/valueType :db/index
-                                                :db/cardinality :db/unique])]
-                                     :in [$ ?mid]
-                                     :where [[?e :attr/migration ?mid]]}
-                             id)]
+                    (db/q db '{:find
+                               [(pull ?e [:db/ident :db/doc
+                                          :db/valueType :db/index
+                                          :db/cardinality :db/unique])]
+                               :in [$ ?mid]
+                               :where [[?e :attr/migration ?mid]]}
+                          id)]
                 (assoc migration :migration/attrs (->> attrs
                                                        (map first)
                                                        (sort-by str))))))
@@ -126,9 +126,9 @@
 
 (defn latest-migration
   "Get the latest migration performed on the given database"
-  [store]
-  (first (store/q
-           store
+  [db]
+  (first (db/q
+           db
            '{:find [?key ?desc (max ?inst)]
              :keys [:migration/key :migration/description :db/txInstant]
              :where [[?e :migration/key ?key ?inst]
@@ -140,39 +140,39 @@
   (do
     (require '[clojure.repl :as repl]
              '[breadbox.app :as breadbox :refer [app]])
-    (def $store (store/database @app)))
+    (def $db (db/database @app)))
 
-  (migrations $store)
+  (migrations $db)
   (map (fn [migration]
          (-> migration
              (select-keys [:migration/key
                            :migration/description
                            :migration/attrs])
              (update :migration/attrs #(map :db/ident %))))
-       (migrations $store))
-  (latest-migration $store)
+       (migrations $db))
+  (latest-migration $db)
 
-  (attrs $store)
-  (attr $store :post/fields)
-  (doc $store :post/fields)
+  (attrs $db)
+  (attr $db :post/fields)
+  (doc $db :post/fields)
 
-  (cardinality $store :post/slug)
-  (cardinality $store :post/fields)
-  (cardinality $store nil)
-  (cardinality $store :fake)
-  (cardinality-one? $store :post/slug)
-  (cardinality-one? $store :post/fields)
-  (cardinality-many? $store :post/slug)
-  (cardinality-many? $store :post/fields)
+  (cardinality $db :post/slug)
+  (cardinality $db :post/fields)
+  (cardinality $db nil)
+  (cardinality $db :fake)
+  (cardinality-one? $db :post/slug)
+  (cardinality-one? $db :post/fields)
+  (cardinality-many? $db :post/slug)
+  (cardinality-many? $db :post/fields)
 
-  (value-type $store :post/fields)
-  (ref? $store :post/fields)
+  (value-type $db :post/fields)
+  (ref? $db :post/fields)
 
-  (attrs-by-type $store #{:db.type/string :db.type/keyword})
-  (attrs-by-type $store :db.type/keyword)
-  (attrs-by-type $store :db.type/ref)
-  (attrs-by-type $store nil)
-  (attrs-by-type $store :fake)
+  (attrs-by-type $db #{:db.type/string :db.type/keyword})
+  (attrs-by-type $db :db.type/keyword)
+  (attrs-by-type $db :db.type/ref)
+  (attrs-by-type $db nil)
+  (attrs-by-type $db :fake)
 
   ;;
   )

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -175,7 +175,7 @@
                      (:route/params match))
                    (bread/dispatcher [router match]
                      (:bread/dispatcher match)))
-          app (defaults/app {:datastore config
+          app (defaults/app {:db config
                              :components {:not-found not-found}
                              :routes {:router router}
                              :i18n {:supported-langs #{:en :fr}}

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -13,10 +13,10 @@
     [systems.bread.alpha.test-helpers :refer [use-datastore]]
     [systems.bread.alpha.cms.defaults :as defaults]))
 
-(def config {:datastore/type :datahike
+(def config {:db/type :datahike
              :store {:backend :mem
                      :id "app-test-db"}
-             :datastore/initial-txns
+             :db/initial-txns
              [;; init post content
               {:db/id "page.home"
                :post/type :post.type/page

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -10,7 +10,7 @@
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.schema :as schema]
-    [systems.bread.alpha.test-helpers :refer [use-datastore]]
+    [systems.bread.alpha.test-helpers :refer [use-db]]
     [systems.bread.alpha.cms.defaults :as defaults]))
 
 (def config {:db/type :datahike
@@ -81,7 +81,7 @@
                :field/key :not-found
                :field/content "404 Pas Trouvé"}]})
 
-(use-datastore :each config)
+(use-db :each config)
 
 (defc layout [{:keys [content]}]
   {}

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -4,7 +4,7 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.component :refer [defc]]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db] ;; TODO ???
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.dispatcher :as dispatcher]

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -4,7 +4,7 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.component :refer [defc]]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.dispatcher :as dispatcher]

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -11,7 +11,7 @@
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.plugin.auth :as auth]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded
-                                              use-datastore]])
+                                              use-db]])
   (:import
     [java.util Date UUID]))
 
@@ -46,7 +46,7 @@
                                                    {:alg :argon2id}))
     (assoc douglass :user/password (hashers/derive "liber4tion"))]})
 
-(use-datastore :each config)
+(use-db :each config)
 
 (defmethod bread/action ::route
   [req _ _]

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -65,7 +65,7 @@
           [{:action/name ::route
             :action/description
             "Return a hard-coded dispatcher for testing purposes"}]}}
-        app-config {:datastore config
+        app-config {:db config
                     :plugins [route-plugin]
                     :cache false
                     :navigation false

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -33,11 +33,11 @@
    :user/two-factor-key "fake"})
 
 (def config
-  {:datastore/type :datahike
+  {:db/type :datahike
    :store {:id "authdb" :backend :mem}
    :recreate? true
    :force? true
-   :datastore/initial-txns
+   :db/initial-txns
    [(assoc angela :user/password (hashers/derive "abolition4lyfe"))
     (assoc bobby :user/password (hashers/derive "pantherz"))
     ;; NOTE: you wouldn't normally mix and match hashing algorithms like this.

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -6,7 +6,7 @@
     [ring.middleware.session.store :as ss]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.cms.defaults :as defaults]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.internal.time :as t]
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.plugin.auth :as auth]

--- a/test/core/systems/bread/alpha/database_datahike_test.cljc
+++ b/test/core/systems/bread/alpha/database_datahike_test.cljc
@@ -6,7 +6,7 @@
     [systems.bread.alpha.database :as store]))
 
 ;; Set up a bunch of boilerplate to share between tests.
-(let [config {:datastore/type :datahike
+(let [config {:db/type :datahike
               :store {:backend :mem :id "testdb"}
               :initial-tx [{:db/ident :name
                             :db/valueType :db.type/string

--- a/test/core/systems/bread/alpha/database_datahike_test.cljc
+++ b/test/core/systems/bread/alpha/database_datahike_test.cljc
@@ -1,4 +1,4 @@
-;; Tests for the low-level functionality of the Datahike datastore integration.
+;; Tests for the low-level functionality of the Datahike database integration.
 (ns systems.bread.alpha.database-datahike-test
   (:require
     [clojure.test :refer [deftest is testing use-fixtures]]

--- a/test/core/systems/bread/alpha/database_datahike_test.cljc
+++ b/test/core/systems/bread/alpha/database_datahike_test.cljc
@@ -3,7 +3,7 @@
   (:require
     [clojure.test :refer [deftest is testing use-fixtures]]
     [datahike.db]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 ;; Set up a bunch of boilerplate to share between tests.
 (let [config {:datastore/type :datahike

--- a/test/core/systems/bread/alpha/database_datahike_test.cljc
+++ b/test/core/systems/bread/alpha/database_datahike_test.cljc
@@ -1,8 +1,9 @@
 ;; Tests for the low-level functionality of the Datahike datastore integration.
-(ns systems.bread.alpha.datastore-datahike-test
+(ns systems.bread.alpha.database-datahike-test
   (:require
-    [systems.bread.alpha.datastore :as store]
-    [clojure.test :refer [deftest is testing use-fixtures]]))
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [datahike.db]
+    [systems.bread.alpha.datastore :as store]))
 
 ;; Set up a bunch of boilerplate to share between tests.
 (let [config {:datastore/type :datahike

--- a/test/core/systems/bread/alpha/database_test.clj
+++ b/test/core/systems/bread/alpha/database_test.clj
@@ -14,7 +14,7 @@
   (testing "it gives a friendly error message if you forget :db/type"
     (is (thrown-with-msg?
           ExceptionInfo
-          #"No :db/type specified in datastore config!"
+          #"No :db/type specified in database config!"
           (store/connect {:db/typo :datahike}))))
 
   (testing "it gives a friendly error message if you pass a bad :db/type"

--- a/test/core/systems/bread/alpha/database_test.clj
+++ b/test/core/systems/bread/alpha/database_test.clj
@@ -3,7 +3,7 @@
     [kaocha.repl :as k]
     [clojure.test :refer [are deftest is testing]]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded]])
   (:import
     [clojure.lang ExceptionInfo]))
@@ -15,36 +15,36 @@
     (is (thrown-with-msg?
           ExceptionInfo
           #"No :db/type specified in database config!"
-          (store/connect {:db/typo :datahike}))))
+          (db/connect {:db/typo :datahike}))))
 
   (testing "it gives a friendly error message if you pass a bad :db/type"
     (is (thrown-with-msg?
           ExceptionInfo
           #"Unknown :db/type `:oops`! Did you forget to load a plugin\?"
-          (store/connect {:db/type :oops})))))
+          (db/connect {:db/type :oops})))))
 
 (deftest test-add-txs-adds-an-effect
   (let [conn {:fake :db}]
     (are
       [effects args]
       (= effects (let [app (plugins->loaded [{:config {:db/connection conn}}])]
-                   (::bread/effects (apply store/add-txs app args))))
+                   (::bread/effects (apply db/add-txs app args))))
 
-      [{:effect/name ::store/transact
+      [{:effect/name ::db/transact
         :effect/description "Run database transactions"
         :effect/key nil
         :conn conn
         :txs [:some :fake :transactions]}]
       [[:some :fake :transactions]]
 
-      [{:effect/name ::store/transact
+      [{:effect/name ::db/transact
         :effect/description "Custom description"
         :effect/key nil
         :conn conn
         :txs [:some :fake :transactions]}]
       [[:some :fake :transactions] {:description "Custom description"}]
 
-      [{:effect/name ::store/transact
+      [{:effect/name ::db/transact
         :effect/description "Custom description"
         :effect/key 1234
         :conn conn

--- a/test/core/systems/bread/alpha/database_test.clj
+++ b/test/core/systems/bread/alpha/database_test.clj
@@ -1,4 +1,4 @@
-(ns systems.bread.alpha.datastore-test
+(ns systems.bread.alpha.database-test
   (:require
     [kaocha.repl :as k]
     [clojure.test :refer [are deftest is testing]]

--- a/test/core/systems/bread/alpha/database_test.clj
+++ b/test/core/systems/bread/alpha/database_test.clj
@@ -11,25 +11,23 @@
 
 (deftest test-connect
 
-  (testing "it gives a friendly error message if you forget :datastore/type"
+  (testing "it gives a friendly error message if you forget :db/type"
     (is (thrown-with-msg?
           ExceptionInfo
-          #"No :datastore/type specified in datastore config!"
-          (store/connect {:datastore/typo :datahike}))))
+          #"No :db/type specified in datastore config!"
+          (store/connect {:db/typo :datahike}))))
 
-  (testing "it gives a friendly error message if you pass a bad :datastore/type"
+  (testing "it gives a friendly error message if you pass a bad :db/type"
     (is (thrown-with-msg?
           ExceptionInfo
-          #"Unknown :datastore/type `:oops`! Did you forget to load a plugin\?"
-          (store/connect {:datastore/type :oops})))))
+          #"Unknown :db/type `:oops`! Did you forget to load a plugin\?"
+          (store/connect {:db/type :oops})))))
 
 (deftest test-add-txs-adds-an-effect
   (let [conn {:fake :db}]
     (are
       [effects args]
-      (= effects (let [app (plugins->loaded
-                             [{:config
-                               {:datastore/connection conn}}])]
+      (= effects (let [app (plugins->loaded [{:config {:db/connection conn}}])]
                    (::bread/effects (apply store/add-txs app args))))
 
       [{:effect/name ::store/transact

--- a/test/core/systems/bread/alpha/database_test.clj
+++ b/test/core/systems/bread/alpha/database_test.clj
@@ -3,7 +3,7 @@
     [kaocha.repl :as k]
     [clojure.test :refer [are deftest is testing]]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded]])
   (:import
     [clojure.lang ExceptionInfo]))

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -1,4 +1,4 @@
-(ns systems.bread.alpha.datastore-txs-test
+(ns systems.bread.alpha.database-txs-test
   (:require
     [clojure.test :refer [are deftest testing use-fixtures]]
     [systems.bread.alpha.core :as bread]

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -4,7 +4,7 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.database :as store]
     [systems.bread.alpha.test-helpers :refer [db-config->loaded
-                                              use-datastore]]))
+                                              use-db]]))
 
 (def config {:db/type :datahike
               :store {:backend :mem
@@ -28,7 +28,7 @@
                 :db/valueType :db.type/string
                 :db/cardinality :db.cardinality/one}]})
 
-(use-datastore :each config)
+(use-db :each config)
 
 (deftest test-add-txs
 

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -6,14 +6,14 @@
     [systems.bread.alpha.test-helpers :refer [datastore-config->loaded
                                               use-datastore]]))
 
-(def config {:datastore/type :datahike
+(def config {:db/type :datahike
               :store {:backend :mem
                       :id "plugin-db"}
               ;; Printing the whole schema slows down results on error/failure,
               ;; so just use the mininum viable post schema for what we need
               ;; to run this test.
               ;; TODO get Kaocha not to print debug logs?
-              :datastore/initial-txns
+              :db/initial-txns
               [{:db/ident :post/slug
                 :db/valueType :db.type/string
                 :db/index true

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer [are deftest testing use-fixtures]]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.test-helpers :refer [datastore-config->loaded
                                               use-datastore]]))
 

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -46,7 +46,7 @@
                                   [:field/key :field/content]}])]
                       :in [$ ?slug]
                       :where [[?e :post/slug ?slug]]}]
-                (-> (store/datastore (handler {:uri "/"}))
+                (-> (store/database (handler {:uri "/"}))
                     (store/q query slug)
                     ffirst)))
 

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer [are deftest testing use-fixtures]]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.test-helpers :refer [db-config->loaded
                                               use-db]]))
 
@@ -36,7 +36,7 @@
     (are [page args]
       (= page (let [[slug txs] args
                     app (-> (db-config->loaded config)
-                            (store/add-txs txs))
+                            (db/add-txs txs))
                     handler (bread/handler app)
                     query
                     '{:find
@@ -46,8 +46,8 @@
                                   [:field/key :field/content]}])]
                       :in [$ ?slug]
                       :where [[?e :post/slug ?slug]]}]
-                (-> (store/database (handler {:uri "/"}))
-                    (store/q query slug)
+                (-> (db/database (handler {:uri "/"}))
+                    (db/q query slug)
                     ffirst)))
 
       ;; Without fields.

--- a/test/core/systems/bread/alpha/database_txs_test.clj
+++ b/test/core/systems/bread/alpha/database_txs_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer [are deftest testing use-fixtures]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.database :as store]
-    [systems.bread.alpha.test-helpers :refer [datastore-config->loaded
+    [systems.bread.alpha.test-helpers :refer [db-config->loaded
                                               use-datastore]]))
 
 (def config {:db/type :datahike
@@ -35,7 +35,7 @@
   (testing "it runs zero or more transactions on the database"
     (are [page args]
       (= page (let [[slug txs] args
-                    app (-> (datastore-config->loaded config)
+                    app (-> (db-config->loaded config)
                             (store/add-txs txs))
                     handler (bread/handler app)
                     query

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -31,9 +31,9 @@
       (is (instance? clojure.lang.Atom
                      (bread/config app :db/connection)))))
 
-  (testing ":hook/datastore returns the present snapshot by default"
+  (testing "::store/db returns the present snapshot by default"
     (let [app (db-config->loaded config)]
-      (is (instance? datahike.db.DB (bread/hook app :hook/datastore)))))
+      (is (instance? datahike.db.DB (bread/hook app ::store/db)))))
 
   (testing "db-tx honors as-of-param"
     (let [app (db-config->loaded config)
@@ -75,7 +75,7 @@
                              :params {:as-of "nonsense date string"}})]
       (is (instance? datahike.db.DB (store/datastore response)))))
 
-  (testing "it honors a custom :hook/datastore.req->timepoint callback"
+  (testing "it honors a custom ::timepoint callback"
     (let [->timepoint (constantly (java.util.Date.))
           config (assoc config :db/req->timepoint ->timepoint)
           app (plugins->loaded [(store/plugin config)])]

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -4,8 +4,8 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.database :as store]
     [systems.bread.alpha.plugin.datahike :as plugin]
-    [systems.bread.alpha.test-helpers :as h :refer [datastore-config->loaded
-                                                    datastore-config->handler
+    [systems.bread.alpha.test-helpers :as h :refer [db-config->loaded
+                                                    db-config->handler
                                                     plugins->loaded]]))
 
 (def config
@@ -18,25 +18,25 @@
 (deftest test-datahike-plugin
 
   (testing "it configures as-of-param"
-    (let [app ((datastore-config->handler config) {})]
+    (let [app ((db-config->handler config) {})]
       (is (= :as-of (bread/config app :db/as-of-param)))))
 
   (testing "it honors custom as-of-param"
-    (let [app (datastore-config->loaded
+    (let [app (db-config->loaded
                 (assoc config :db/as-of-param :my/param))]
       (is (= :my/param (bread/config app :db/as-of-param)))))
 
   (testing "it configures db connection"
-    (let [app (datastore-config->loaded config)]
+    (let [app (db-config->loaded config)]
       (is (instance? clojure.lang.Atom
                      (bread/config app :db/connection)))))
 
   (testing ":hook/datastore returns the present snapshot by default"
-    (let [app (datastore-config->loaded config)]
+    (let [app (db-config->loaded config)]
       (is (instance? datahike.db.DB (bread/hook app :hook/datastore)))))
 
   (testing "db-tx honors as-of-param"
-    (let [app (datastore-config->loaded config)
+    (let [app (db-config->loaded config)
           db (store/datastore app)
           handler (bread/handler app)
           max-tx (store/max-tx app)
@@ -44,12 +44,12 @@
       (is (instance? datahike.db.AsOfDB (store/datastore response)))))
 
   (testing "db-tx gracefully handles non-numeric strings"
-    (let [handler (datastore-config->handler config)
+    (let [handler (db-config->handler config)
           response (handler {:uri "/" :params {:as-of "garbage"}})]
       (is (instance? datahike.db.DB (store/datastore response)))))
 
   (testing "db-datetime honors as-of param"
-    (let [handler (datastore-config->handler
+    (let [handler (db-config->handler
                     (assoc config
                            :db/req->timepoint store/db-datetime))
           response (handler {:uri "/"
@@ -58,7 +58,7 @@
       (is (instance? datahike.db.AsOfDB (store/datastore response)))))
 
   (testing "db-datetime honors as-of-format config"
-    (let [handler (datastore-config->handler
+    (let [handler (db-config->handler
                     (assoc config
                            :db/as-of-format "yyyy-MM-dd"
                            :db/req->timepoint store/db-datetime))
@@ -68,7 +68,7 @@
       (is (instance? datahike.db.AsOfDB (store/datastore response)))))
 
   (testing "db-datetime gracefully handles bad date strings"
-    (let [handler (datastore-config->handler
+    (let [handler (db-config->handler
                     (assoc config
                            :db/req->timepoint store/db-datetime))
           response (handler {:uri "/"

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer :all]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.plugin.datahike :as plugin]
     [systems.bread.alpha.test-helpers :as h :refer [datastore-config->loaded
                                                     datastore-config->handler

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer :all]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.plugin.datahike :as plugin]
     [systems.bread.alpha.test-helpers :as h :refer [db-config->loaded
                                                     db-config->handler
@@ -28,48 +28,48 @@
 
   (testing "database returns the present snapshot by default"
     (let [app (db-config->loaded config)]
-      (is (instance? datahike.db.DB (store/database app)))))
+      (is (instance? datahike.db.DB (db/database app)))))
 
   (testing "database honors as-of-tx? config"
     (let [app (db-config->loaded (assoc config :db/as-of-tx? true))
           handler (bread/handler app)
-          max-tx (:max-tx (store/database app))
+          max-tx (:max-tx (db/database app))
           res (handler {:uri "/" :params {:as-of (dec max-tx)}})]
-      (is (instance? datahike.db.AsOfDB (store/database res)))))
+      (is (instance? datahike.db.AsOfDB (db/database res)))))
 
   (testing "database honors as-of-param"
     (let [app (db-config->loaded config)
           handler (bread/handler app)
           res (handler {:uri "/" :params {:as-of
                                           "2020-01-01 12:34:56 PDT"}})]
-      (is (instance? datahike.db.AsOfDB (store/database res))))
+      (is (instance? datahike.db.AsOfDB (db/database res))))
 
     (let [app (db-config->loaded (assoc config :db/as-of-param :my-param))
           handler (bread/handler app)
           res (handler {:uri "/" :params {:my-param
                                           "2020-01-01 12:34:56 PDT"}})]
-      (is (instance? datahike.db.AsOfDB (store/database res)))))
+      (is (instance? datahike.db.AsOfDB (db/database res)))))
 
   (testing "database gracefully handles non-numeric strings"
     (let [handler (db-config->handler config)
           res (handler {:uri "/" :params {:as-of "garbage"}})]
-      (is (instance? datahike.db.DB (store/database res)))))
+      (is (instance? datahike.db.DB (db/database res)))))
 
-  (testing "database calls the ::store/timepoint hook"
-    (let [app (plugins->loaded [(store/plugin config)
+  (testing "database calls the ::db/timepoint hook"
+    (let [app (plugins->loaded [(db/plugin config)
                                 {:hooks
-                                 {::store/timepoint
+                                 {::db/timepoint
                                   [{:action/name ::bread/value
                                     :action/value (java.util.Date.)}]}}])
           handler (bread/handler app)
           res (handler {:uri "/"})]
-      (is (instance? datahike.db.AsOfDB (store/database res)))))
+      (is (instance? datahike.db.AsOfDB (db/database res)))))
 
   (testing "database honors as-of-format config"
     (let [handler (db-config->handler
                     (assoc config :db/as-of-format "yyyy-MM-dd"))
           res (handler {:uri "/" :params {:as-of "2020-01-01"}})]
-      (is (instance? datahike.db.AsOfDB (store/database res))))))
+      (is (instance? datahike.db.AsOfDB (db/database res))))))
 
 (comment
   (require '[kaocha.repl :as k])

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -26,9 +26,9 @@
       (is (instance? clojure.lang.Atom
                      (bread/config app :db/connection)))))
 
-  (testing "::store/db returns the present snapshot by default"
+  (testing "datastore returns the present snapshot by default"
     (let [app (db-config->loaded config)]
-      (is (instance? datahike.db.DB (bread/hook app ::store/db)))))
+      (is (instance? datahike.db.DB (store/datastore app)))))
 
   (testing "datastore honors as-of-tx? config"
     (let [app (db-config->loaded (assoc config :db/as-of-tx? true))

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -26,36 +26,36 @@
       (is (instance? clojure.lang.Atom
                      (bread/config app :db/connection)))))
 
-  (testing "datastore returns the present snapshot by default"
+  (testing "database returns the present snapshot by default"
     (let [app (db-config->loaded config)]
-      (is (instance? datahike.db.DB (store/datastore app)))))
+      (is (instance? datahike.db.DB (store/database app)))))
 
-  (testing "datastore honors as-of-tx? config"
+  (testing "database honors as-of-tx? config"
     (let [app (db-config->loaded (assoc config :db/as-of-tx? true))
           handler (bread/handler app)
-          max-tx (:max-tx (store/datastore app))
+          max-tx (:max-tx (store/database app))
           res (handler {:uri "/" :params {:as-of (dec max-tx)}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore res)))))
+      (is (instance? datahike.db.AsOfDB (store/database res)))))
 
-  (testing "datastore honors as-of-param"
+  (testing "database honors as-of-param"
     (let [app (db-config->loaded config)
           handler (bread/handler app)
           res (handler {:uri "/" :params {:as-of
                                           "2020-01-01 12:34:56 PDT"}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore res))))
+      (is (instance? datahike.db.AsOfDB (store/database res))))
 
     (let [app (db-config->loaded (assoc config :db/as-of-param :my-param))
           handler (bread/handler app)
           res (handler {:uri "/" :params {:my-param
                                           "2020-01-01 12:34:56 PDT"}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore res)))))
+      (is (instance? datahike.db.AsOfDB (store/database res)))))
 
-  (testing "datastore gracefully handles non-numeric strings"
+  (testing "database gracefully handles non-numeric strings"
     (let [handler (db-config->handler config)
           res (handler {:uri "/" :params {:as-of "garbage"}})]
-      (is (instance? datahike.db.DB (store/datastore res)))))
+      (is (instance? datahike.db.DB (store/database res)))))
 
-  (testing "datastore calls the ::store/timepoint hook"
+  (testing "database calls the ::store/timepoint hook"
     (let [app (plugins->loaded [(store/plugin config)
                                 {:hooks
                                  {::store/timepoint
@@ -63,13 +63,13 @@
                                     :action/value (java.util.Date.)}]}}])
           handler (bread/handler app)
           res (handler {:uri "/"})]
-      (is (instance? datahike.db.AsOfDB (store/datastore res)))))
+      (is (instance? datahike.db.AsOfDB (store/database res)))))
 
-  (testing "datastore honors as-of-format config"
+  (testing "database honors as-of-format config"
     (let [handler (db-config->handler
                     (assoc config :db/as-of-format "yyyy-MM-dd"))
           res (handler {:uri "/" :params {:as-of "2020-01-01"}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore res))))))
+      (is (instance? datahike.db.AsOfDB (store/database res))))))
 
 (comment
   (require '[kaocha.repl :as k])

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -13,7 +13,7 @@
    :store {:backend :mem
            :id "plugin-db"}})
 
-(h/use-datastore :each config)
+(h/use-db :each config)
 
 (deftest test-datahike-plugin
 

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -9,7 +9,7 @@
                                                     plugins->loaded]]))
 
 (def config
-  {:datastore/type :datahike
+  {:db/type :datahike
    :store {:backend :mem
            :id "plugin-db"}})
 
@@ -19,17 +19,17 @@
 
   (testing "it configures as-of-param"
     (let [app ((datastore-config->handler config) {})]
-      (is (= :as-of (bread/config app :datastore/as-of-param)))))
+      (is (= :as-of (bread/config app :db/as-of-param)))))
 
   (testing "it honors custom as-of-param"
     (let [app (datastore-config->loaded
-                (assoc config :datastore/as-of-param :my/param))]
-      (is (= :my/param (bread/config app :datastore/as-of-param)))))
+                (assoc config :db/as-of-param :my/param))]
+      (is (= :my/param (bread/config app :db/as-of-param)))))
 
   (testing "it configures db connection"
     (let [app (datastore-config->loaded config)]
       (is (instance? clojure.lang.Atom
-                     (bread/config app :datastore/connection)))))
+                     (bread/config app :db/connection)))))
 
   (testing ":hook/datastore returns the present snapshot by default"
     (let [app (datastore-config->loaded config)]
@@ -51,7 +51,7 @@
   (testing "db-datetime honors as-of param"
     (let [handler (datastore-config->handler
                     (assoc config
-                           :datastore/req->timepoint store/db-datetime))
+                           :db/req->timepoint store/db-datetime))
           response (handler {:uri "/"
                              ;; pass a literal date here
                              :params {:as-of "2020-01-01 00:00:00 PDT"}})]
@@ -60,8 +60,8 @@
   (testing "db-datetime honors as-of-format config"
     (let [handler (datastore-config->handler
                     (assoc config
-                           :datastore/as-of-format "yyyy-MM-dd"
-                           :datastore/req->timepoint store/db-datetime))
+                           :db/as-of-format "yyyy-MM-dd"
+                           :db/req->timepoint store/db-datetime))
           response (handler {:uri "/"
                              ;; pass a literal date here
                              :params {:as-of "2020-01-01"}})]
@@ -70,14 +70,14 @@
   (testing "db-datetime gracefully handles bad date strings"
     (let [handler (datastore-config->handler
                     (assoc config
-                           :datastore/req->timepoint store/db-datetime))
+                           :db/req->timepoint store/db-datetime))
           response (handler {:uri "/"
                              :params {:as-of "nonsense date string"}})]
       (is (instance? datahike.db.DB (store/datastore response)))))
 
   (testing "it honors a custom :hook/datastore.req->timepoint callback"
     (let [->timepoint (constantly (java.util.Date.))
-          config (assoc config :datastore/req->timepoint ->timepoint)
+          config (assoc config :db/req->timepoint ->timepoint)
           app (plugins->loaded [(store/plugin config)])]
       (is (instance? datahike.db.AsOfDB (store/datastore app))))))
 

--- a/test/core/systems/bread/alpha/datahike_plugin_test.clj
+++ b/test/core/systems/bread/alpha/datahike_plugin_test.clj
@@ -17,14 +17,9 @@
 
 (deftest test-datahike-plugin
 
-  (testing "it configures as-of-param"
+  (testing "it configures a default as-of-param"
     (let [app ((db-config->handler config) {})]
       (is (= :as-of (bread/config app :db/as-of-param)))))
-
-  (testing "it honors custom as-of-param"
-    (let [app (db-config->loaded
-                (assoc config :db/as-of-param :my/param))]
-      (is (= :my/param (bread/config app :db/as-of-param)))))
 
   (testing "it configures db connection"
     (let [app (db-config->loaded config)]
@@ -35,51 +30,46 @@
     (let [app (db-config->loaded config)]
       (is (instance? datahike.db.DB (bread/hook app ::store/db)))))
 
-  (testing "db-tx honors as-of-param"
-    (let [app (db-config->loaded config)
-          db (store/datastore app)
+  (testing "datastore honors as-of-tx? config"
+    (let [app (db-config->loaded (assoc config :db/as-of-tx? true))
           handler (bread/handler app)
-          max-tx (store/max-tx app)
-          response (handler {:uri "/" :params {:as-of (dec max-tx)}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore response)))))
+          max-tx (:max-tx (store/datastore app))
+          res (handler {:uri "/" :params {:as-of (dec max-tx)}})]
+      (is (instance? datahike.db.AsOfDB (store/datastore res)))))
 
-  (testing "db-tx gracefully handles non-numeric strings"
+  (testing "datastore honors as-of-param"
+    (let [app (db-config->loaded config)
+          handler (bread/handler app)
+          res (handler {:uri "/" :params {:as-of
+                                          "2020-01-01 12:34:56 PDT"}})]
+      (is (instance? datahike.db.AsOfDB (store/datastore res))))
+
+    (let [app (db-config->loaded (assoc config :db/as-of-param :my-param))
+          handler (bread/handler app)
+          res (handler {:uri "/" :params {:my-param
+                                          "2020-01-01 12:34:56 PDT"}})]
+      (is (instance? datahike.db.AsOfDB (store/datastore res)))))
+
+  (testing "datastore gracefully handles non-numeric strings"
     (let [handler (db-config->handler config)
-          response (handler {:uri "/" :params {:as-of "garbage"}})]
-      (is (instance? datahike.db.DB (store/datastore response)))))
+          res (handler {:uri "/" :params {:as-of "garbage"}})]
+      (is (instance? datahike.db.DB (store/datastore res)))))
 
-  (testing "db-datetime honors as-of param"
+  (testing "datastore calls the ::store/timepoint hook"
+    (let [app (plugins->loaded [(store/plugin config)
+                                {:hooks
+                                 {::store/timepoint
+                                  [{:action/name ::bread/value
+                                    :action/value (java.util.Date.)}]}}])
+          handler (bread/handler app)
+          res (handler {:uri "/"})]
+      (is (instance? datahike.db.AsOfDB (store/datastore res)))))
+
+  (testing "datastore honors as-of-format config"
     (let [handler (db-config->handler
-                    (assoc config
-                           :db/req->timepoint store/db-datetime))
-          response (handler {:uri "/"
-                             ;; pass a literal date here
-                             :params {:as-of "2020-01-01 00:00:00 PDT"}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore response)))))
-
-  (testing "db-datetime honors as-of-format config"
-    (let [handler (db-config->handler
-                    (assoc config
-                           :db/as-of-format "yyyy-MM-dd"
-                           :db/req->timepoint store/db-datetime))
-          response (handler {:uri "/"
-                             ;; pass a literal date here
-                             :params {:as-of "2020-01-01"}})]
-      (is (instance? datahike.db.AsOfDB (store/datastore response)))))
-
-  (testing "db-datetime gracefully handles bad date strings"
-    (let [handler (db-config->handler
-                    (assoc config
-                           :db/req->timepoint store/db-datetime))
-          response (handler {:uri "/"
-                             :params {:as-of "nonsense date string"}})]
-      (is (instance? datahike.db.DB (store/datastore response)))))
-
-  (testing "it honors a custom ::timepoint callback"
-    (let [->timepoint (constantly (java.util.Date.))
-          config (assoc config :db/req->timepoint ->timepoint)
-          app (plugins->loaded [(store/plugin config)])]
-      (is (instance? datahike.db.AsOfDB (store/datastore app))))))
+                    (assoc config :db/as-of-format "yyyy-MM-dd"))
+          res (handler {:uri "/" :params {:as-of "2020-01-01"}})]
+      (is (instance? datahike.db.AsOfDB (store/datastore res))))))
 
 (comment
   (require '[kaocha.repl :as k])

--- a/test/core/systems/bread/alpha/datahike_query_test.clj
+++ b/test/core/systems/bread/alpha/datahike_query_test.clj
@@ -7,9 +7,9 @@
     [systems.bread.alpha.database :as store]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded use-datastore]]))
 
-(def config {:datastore/type :datahike
+(def config {:db/type :datahike
              :store {:backend :mem :id "expand-db"}
-             :datastore/initial-txns
+             :db/initial-txns
              [;; init simplified schema
               {:db/ident :post/slug
                :db/valueType :db.type/string

--- a/test/core/systems/bread/alpha/datahike_query_test.clj
+++ b/test/core/systems/bread/alpha/datahike_query_test.clj
@@ -57,7 +57,7 @@
 (deftest test-datahike-query
 
   (let [app (plugins->loaded [(store/plugin config) (query/plugin)])
-        db (store/datastore app)]
+        db (store/database app)]
     (are
       [data queries]
       (= data (-> app

--- a/test/core/systems/bread/alpha/datahike_query_test.clj
+++ b/test/core/systems/bread/alpha/datahike_query_test.clj
@@ -5,7 +5,7 @@
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.database :as store]
-    [systems.bread.alpha.test-helpers :refer [plugins->loaded use-datastore]]))
+    [systems.bread.alpha.test-helpers :refer [plugins->loaded use-db]]))
 
 (def config {:db/type :datahike
              :store {:backend :mem :id "expand-db"}
@@ -52,7 +52,7 @@
                               :field/lang :fr
                               :field/content "chose"}]}]})
 
-(use-datastore :each config)
+(use-db :each config)
 
 (deftest test-datahike-query
 

--- a/test/core/systems/bread/alpha/datahike_query_test.clj
+++ b/test/core/systems/bread/alpha/datahike_query_test.clj
@@ -4,7 +4,7 @@
     [kaocha.repl :as k]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded use-datastore]]))
 
 (def config {:datastore/type :datahike

--- a/test/core/systems/bread/alpha/datahike_query_test.clj
+++ b/test/core/systems/bread/alpha/datahike_query_test.clj
@@ -4,7 +4,7 @@
     [kaocha.repl :as k]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded use-db]]))
 
 (def config {:db/type :datahike
@@ -56,8 +56,8 @@
 
 (deftest test-datahike-query
 
-  (let [app (plugins->loaded [(store/plugin config) (query/plugin)])
-        db (store/database app)]
+  (let [app (plugins->loaded [(db/plugin config) (query/plugin)])
+        db (db/database app)]
     (are
       [data queries]
       (= data (-> app
@@ -70,7 +70,7 @@
        ;; Querying for a non-existent post
        {:post false
         :not-found? true}
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :post
          :query/db db
          :query/args
@@ -83,7 +83,7 @@
        ;; Querying for a non-existent post and its fields
        {:post false
         :not-found? true}
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :post
          :query/db db
          :query/args
@@ -93,7 +93,7 @@
             :where [[?e :post/slug ?slug]]}
           "non-existent-slug"]}
         {:query/key [:post :post/fields]
-         :query/name ::store/query
+         :query/name ::db/query
          :query/db db
          :query/args
          ['{:find [(pull ?e [:field/key :field/content])]
@@ -109,7 +109,7 @@
                              {:field/key :stuff :field/lang :fr}
                              {:field/key :thingy :field/lang :fr}]}
         :not-found? false}
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :post
          :query/db db
          :query/args
@@ -125,7 +125,7 @@
                              {:field/key :stuff :field/lang :fr}
                              {:field/key :thingy :field/lang :fr}]}
         :not-found? false}
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :post
          :query/db db
          :query/args
@@ -143,7 +143,7 @@
                              [{:field/key :stuff
                               :field/content "hello"}]]}
         :not-found? false}
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :post
          :query/db db
          :query/args
@@ -151,7 +151,7 @@
             :in [$ ?slug]
             :where [[?e :post/slug ?slug]]}
           "parent-post"]}
-        {:query/name ::store/query
+        {:query/name ::db/query
          :query/key [:post :post/fields]
          :query/db db
          :query/args
@@ -169,7 +169,7 @@
                              [{:field/key :stuff
                                :field/content "hello"}]]}
         :not-found? false}
-       [{:query/name ::store/query
+       [{:query/name ::db/query
          :query/key :post
          :query/db db
          :query/args
@@ -177,7 +177,7 @@
             :in [$ ?slug]
             :where [[?e :post/slug ?slug]]}
           "parent-post"]}
-        {:query/name ::store/query
+        {:query/name ::db/query
          :query/key [:post :post/fields]
          :query/db db
          :query/args

--- a/test/core/systems/bread/alpha/datastore_datahike_test.cljc
+++ b/test/core/systems/bread/alpha/datastore_datahike_test.cljc
@@ -18,11 +18,11 @@
 
       datahike-fixture (fn [f]
                          ;; Clean up after any prior failures, just in case.
-                         (store/delete-database! config)
-                         (store/create-database! config)
+                         (store/delete! config)
+                         (store/create! config)
                          (f)
                          ;; Eagerly clean up after ourselves.
-                         (store/delete-database! config))
+                         (store/delete! config))
 
       angela {:name "Angela" :age 76}
       bobby {:name "Bobby" :age 84}
@@ -31,7 +31,7 @@
                   [?e :name ?n]
                   [?e :age ?a]]
       init-db (fn []
-                (let [conn (store/connect! config)]
+                (let [conn (store/connect config)]
                   (store/transact conn [angela bobby])
                   conn))]
 

--- a/test/core/systems/bread/alpha/datastore_test.clj
+++ b/test/core/systems/bread/alpha/datastore_test.clj
@@ -9,19 +9,19 @@
     [clojure.lang ExceptionInfo]))
 
 
-(deftest test-connect!
+(deftest test-connect
 
   (testing "it gives a friendly error message if you forget :datastore/type"
     (is (thrown-with-msg?
           ExceptionInfo
           #"No :datastore/type specified in datastore config!"
-          (store/connect! {:datastore/typo :datahike}))))
+          (store/connect {:datastore/typo :datahike}))))
 
   (testing "it gives a friendly error message if you pass a bad :datastore/type"
     (is (thrown-with-msg?
           ExceptionInfo
           #"Unknown :datastore/type `:oops`! Did you forget to load a plugin\?"
-          (store/connect! {:datastore/type :oops})))))
+          (store/connect {:datastore/type :oops})))))
 
 (deftest test-add-txs-adds-an-effect
   (let [conn {:fake :db}]

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -8,7 +8,7 @@
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.test-helpers :refer [plugins->loaded
-                                              use-datastore]]))
+                                              use-db]]))
 
 (def config {:db/type :datahike
              :store {:backend :mem
@@ -26,7 +26,7 @@
               {:field/key :one :field/content "Uno" :field/lang :es}
               {:field/key :two :field/content "Dos" :field/lang :es}]})
 
-(use-datastore :each config)
+(use-db :each config)
 
 (defmethod bread/action ::naive-params
   [{:keys [uri] :as req} _ _]

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [clojure.test :refer [are deftest is testing use-fixtures]]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.route :as route]

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -3,7 +3,7 @@
     [clojure.string :as string]
     [clojure.test :refer [are deftest is testing use-fixtures]]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.query :as query]
     [systems.bread.alpha.route :as route]
@@ -38,7 +38,7 @@
   {:hooks {::route/params [{:action/name ::naive-params}]}})
 
 (defn- load-app [i18n-config]
-  (plugins->loaded [(store/plugin config)
+  (plugins->loaded [(db/plugin config)
                     (i18n/plugin i18n-config)
                     naive-plugin]))
 
@@ -95,7 +95,7 @@
 
 ;; i18n/plugin loads I18n strings for the given language automatically.
 (deftest test-add-i18n-query
-  (let [app (plugins->loaded [(store/plugin config)
+  (let [app (plugins->loaded [(db/plugin config)
                               (i18n/plugin {:supported-langs #{:en :es}})
                               (query/plugin)
                               naive-plugin])]
@@ -124,7 +124,7 @@
 
 (deftest test-fallback
   (let [load-app #(plugins->loaded
-                    [(store/plugin config)
+                    [(db/plugin config)
                      (i18n/plugin (merge {:supported-langs #{:en :es}} %))
                      (query/plugin)
                      naive-plugin])]
@@ -168,7 +168,7 @@
                  (bread/hook app ::i18n/queries [query])))
 
     ;; Without :field/content
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post
       :query/db ::FAKEDB
       :query/args
@@ -176,7 +176,7 @@
          :in [$ ?type]
          :where [[?e :post/type ?type]]}
        :post.type/page]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post
       :query/db ::FAKEDB
       :query/args
@@ -187,7 +187,7 @@
      :whatever]
 
     ;; With :translatable/fields, but still without :field/content
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post
       :query/db ::FAKEDB
       :query/args
@@ -197,7 +197,7 @@
          :in [$ ?type]
          :where [[?e :post/type ?type]]}
        :post.type/page]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post
       :query/db ::FAKEDB
       :query/args
@@ -210,7 +210,7 @@
      :whatever]
 
     ;; With :field/content
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post-with-content
       :query/db ::FAKEDB
       :query/args
@@ -218,7 +218,7 @@
          :in [$ ?type]
          :where [[?e :post/type ?type]]}
        :post.type/page]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:post-with-content :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -228,7 +228,7 @@
                  [?e0 :translatable/fields ?e]]}
        [::bread/data :post-with-content :db/id]
        :fr]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post-with-content
       :query/db ::FAKEDB
       :query/args
@@ -241,7 +241,7 @@
      :fr]
 
     ;; With :field/content implicity as part of {:translatable/fields [*]}
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post
       :query/db ::FAKEDB
       :query/args
@@ -249,7 +249,7 @@
          :in [$ ?type]
          :where [[?e :post/type ?type]]}
        :post.type/page]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:post :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -259,7 +259,7 @@
                  [?e0 :translatable/fields ?e]]}
        [::bread/data :post :db/id]
        :ru]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post
       :query/db ::FAKEDB
       :query/args
@@ -270,7 +270,7 @@
      :ru]
 
     ;; With :field/content implicity as part of {:translatable/fields [*]}
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :taxon
       :query/db ::FAKEDB
       :query/args
@@ -278,7 +278,7 @@
          :in [$ ?taxonomy]
          :where [[?e :taxon/taxonomy ?taxonomy]]}
        :taxon.taxonomy/tag]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:taxon :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -288,7 +288,7 @@
                  [?e0 :translatable/fields ?e]]}
        [::bread/data :taxon :db/id]
        :es]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :taxon
       :query/db ::FAKEDB
       :query/args
@@ -299,7 +299,7 @@
      :es]
 
     ;; With deeply nested, mixed implicit & explicit :field/content
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post-with-taxons-and-field-content
       :query/db ::FAKEDB
       :query/args
@@ -314,7 +314,7 @@
                  [?e :post/type ?type]]}
        "my-post"
        :post.type/page]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:post-with-taxons-and-field-content :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -324,7 +324,7 @@
                  [?e0 :translatable/fields ?e]]}
        [::bread/data :post-with-taxons-and-field-content :db/id]
        :en]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:post-with-taxons-and-field-content :post/taxons :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -339,7 +339,7 @@
        ;; Get the post ID to be passed in from this data path.
        [::bread/data :post-with-taxons-and-field-content :db/id]
        :en]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post-with-taxons-and-field-content
       :query/db ::FAKEDB
       :query/args
@@ -357,7 +357,7 @@
      :en]
 
     ;; With posts nested under a taxon
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :nested-taxon
       :query/db ::FAKEDB
       :query/args
@@ -377,7 +377,7 @@
        :post.type/page
        :taxon.taxonomy/category
        "my-cat"]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:nested-taxon :post/_taxons :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -394,7 +394,7 @@
        ;; Get the post ID to be passed in from this data path.
        [::bread/data :nested-taxon :db/id]
        :fr]}]
-    [{:query/name ::store/query,
+    [{:query/name ::db/query,
       :query/key :nested-taxon,
       :query/db ::FAKEDB,
       :query/args
@@ -421,7 +421,7 @@
      :fr]
 
     ;; With deeply nested, implicit :field/content
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post-with-fields-and-taxons
       :query/db ::FAKEDB
       :query/args
@@ -436,7 +436,7 @@
                  [?e :post/type ?type]]}
        "my-post"
        :post.type/page]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:post-with-fields-and-taxons :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -446,7 +446,7 @@
                  [?e0 :translatable/fields ?e]]}
        [::bread/data :post-with-fields-and-taxons :db/id]
        :de]}
-     {:query/name ::store/query
+     {:query/name ::db/query
       :query/key [:post-with-fields-and-taxons :post/taxons :translatable/fields]
       :query/db ::FAKEDB
       :query/args
@@ -461,7 +461,7 @@
        ;; Get the post ID to be passed in from this data path.
        [::bread/data :post-with-fields-and-taxons :db/id]
        :de]}]
-    [{:query/name ::store/query
+    [{:query/name ::db/query
       :query/key :post-with-fields-and-taxons
       :query/db ::FAKEDB
       :query/args

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -10,10 +10,10 @@
     [systems.bread.alpha.test-helpers :refer [plugins->loaded
                                               use-datastore]]))
 
-(def config {:datastore/type :datahike
+(def config {:db/type :datahike
              :store {:backend :mem
                      :id "test-i18n-db"}
-             :datastore/initial-txns
+             :db/initial-txns
              ;; TODO test locales e.g. en-gb
              [{:translatable/fields #{{:field/key :one
                                        :field/content "Post One"

--- a/test/core/systems/bread/alpha/install_test.clj
+++ b/test/core/systems/bread/alpha/install_test.clj
@@ -4,7 +4,7 @@
    [systems.bread.alpha.database :as store]
    [systems.bread.alpha.schema :as schema]
    [systems.bread.alpha.plugin.datahike]
-   [systems.bread.alpha.test-helpers :refer [datastore-config->loaded]]))
+   [systems.bread.alpha.test-helpers :refer [db-config->loaded]]))
 
 (defonce config {:db/type :datahike
                  :store {:backend :mem :id "install-db"}})
@@ -24,7 +24,7 @@
                         #{:bread.migration/migrations
                           :bread.migration/posts}})]
     (store/create! config)
-    (datastore-config->loaded (assoc config :db/migrations
+    (db-config->loaded (assoc config :db/migrations
                                      (conj schema/initial my-migration)))
     (are
       [pred migration] (pred (store/migration-ran?
@@ -49,8 +49,8 @@
     (store/create! config)
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Migration has one or more unmet dependencies!"
-                          (datastore-config->loaded config)))
+                          (db-config->loaded config)))
     (is (= #{:UNMET} (try
-                       (datastore-config->loaded config)
+                       (db-config->loaded config)
                        (catch clojure.lang.ExceptionInfo ex
                          (:unmet-deps (ex-data ex))))))))

--- a/test/core/systems/bread/alpha/install_test.clj
+++ b/test/core/systems/bread/alpha/install_test.clj
@@ -6,7 +6,7 @@
    [systems.bread.alpha.plugin.datahike]
    [systems.bread.alpha.test-helpers :refer [datastore-config->loaded]]))
 
-(defonce config {:datastore/type :datahike
+(defonce config {:db/type :datahike
                  :store {:backend :mem :id "install-db"}})
 
 (defn- wrap-db-installation [run]
@@ -24,7 +24,7 @@
                         #{:bread.migration/migrations
                           :bread.migration/posts}})]
     (store/create! config)
-    (datastore-config->loaded (assoc config :datastore/migrations
+    (datastore-config->loaded (assoc config :db/migrations
                                      (conj schema/initial my-migration)))
     (are
       [pred migration] (pred (store/migration-ran?
@@ -45,7 +45,7 @@
   (let [my-migration (with-meta
                        [{:migration/key :my/migration}]
                        {:migration/dependencies #{:UNMET}})
-        config (assoc config :datastore/migrations [my-migration])]
+        config (assoc config :db/migrations [my-migration])]
     (store/create! config)
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Migration has one or more unmet dependencies!"

--- a/test/core/systems/bread/alpha/install_test.clj
+++ b/test/core/systems/bread/alpha/install_test.clj
@@ -1,7 +1,7 @@
 (ns systems.bread.alpha.install-test
   (:require
    [clojure.test :refer [deftest are is use-fixtures]]
-   [systems.bread.alpha.datastore :as store]
+   [systems.bread.alpha.database :as store]
    [systems.bread.alpha.schema :as schema]
    [systems.bread.alpha.plugin.datahike]
    [systems.bread.alpha.test-helpers :refer [datastore-config->loaded]]))

--- a/test/core/systems/bread/alpha/install_test.clj
+++ b/test/core/systems/bread/alpha/install_test.clj
@@ -1,7 +1,7 @@
 (ns systems.bread.alpha.install-test
   (:require
    [clojure.test :refer [deftest are is use-fixtures]]
-   [systems.bread.alpha.database :as store]
+   [systems.bread.alpha.database :as db]
    [systems.bread.alpha.schema :as schema]
    [systems.bread.alpha.plugin.datahike]
    [systems.bread.alpha.test-helpers :refer [db-config->loaded]]))
@@ -11,9 +11,9 @@
 
 (defn- wrap-db-installation [run]
   ;; Clean up after any bad test runs
-  (store/delete! config)
+  (db/delete! config)
   (run)
-  (store/delete! config))
+  (db/delete! config))
 
 (use-fixtures :each wrap-db-installation)
 
@@ -23,12 +23,12 @@
                        {:migration/dependencies
                         #{:bread.migration/migrations
                           :bread.migration/posts}})]
-    (store/create! config)
+    (db/create! config)
     (db-config->loaded (assoc config :db/migrations
                                      (conj schema/initial my-migration)))
     (are
-      [pred migration] (pred (store/migration-ran?
-                               (store/db (store/connect config))
+      [pred migration] (pred (db/migration-ran?
+                               (db/db (db/connect config))
                                migration))
       true? schema/migrations
       true? schema/posts
@@ -46,7 +46,7 @@
                        [{:migration/key :my/migration}]
                        {:migration/dependencies #{:UNMET}})
         config (assoc config :db/migrations [my-migration])]
-    (store/create! config)
+    (db/create! config)
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Migration has one or more unmet dependencies!"
                           (db-config->loaded config)))

--- a/test/core/systems/bread/alpha/install_test.clj
+++ b/test/core/systems/bread/alpha/install_test.clj
@@ -11,9 +11,9 @@
 
 (defn- wrap-db-installation [run]
   ;; Clean up after any bad test runs
-  (store/delete-database! config)
+  (store/delete! config)
   (run)
-  (store/delete-database! config))
+  (store/delete! config))
 
 (use-fixtures :each wrap-db-installation)
 
@@ -25,7 +25,7 @@
   (is (true? (store/installed? config))))
 
 (deftest test-delete-database
-  (store/delete-database! config)
+  (store/delete! config)
   (is (false? (store/installed? config))))
 
 (deftest test-migrations
@@ -39,7 +39,7 @@
                                      (conj schema/initial my-migration)))
     (are
       [pred migration] (pred (store/migration-ran?
-                               (store/db (store/connect! config))
+                               (store/db (store/connect config))
                                migration))
       true? schema/migrations
       true? schema/posts

--- a/test/core/systems/bread/alpha/install_test.clj
+++ b/test/core/systems/bread/alpha/install_test.clj
@@ -17,24 +17,13 @@
 
 (use-fixtures :each wrap-db-installation)
 
-(deftest test-uninstalled
-  (is (false? (store/installed? config))))
-
-(deftest test-installation
-  (store/install! config)
-  (is (true? (store/installed? config))))
-
-(deftest test-delete-database
-  (store/delete! config)
-  (is (false? (store/installed? config))))
-
 (deftest test-migrations
   (let [my-migration (with-meta
                        [{:migration/key :my/migration}]
                        {:migration/dependencies
                         #{:bread.migration/migrations
                           :bread.migration/posts}})]
-    (store/install! config)
+    (store/create! config)
     (datastore-config->loaded (assoc config :datastore/migrations
                                      (conj schema/initial my-migration)))
     (are
@@ -57,7 +46,7 @@
                        [{:migration/key :my/migration}]
                        {:migration/dependencies #{:UNMET}})
         config (assoc config :datastore/migrations [my-migration])]
-    (store/install! config)
+    (store/create! config)
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Migration has one or more unmet dependencies!"
                           (datastore-config->loaded config)))

--- a/test/core/systems/bread/alpha/internal_query_inference_test.clj
+++ b/test/core/systems/bread/alpha/internal_query_inference_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer [deftest are is]]
     [systems.bread.alpha.internal.query-inference :as i]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.i18n :as i18n]))
 
 (deftest test-binding-pairs

--- a/test/core/systems/bread/alpha/internal_query_inference_test.clj
+++ b/test/core/systems/bread/alpha/internal_query_inference_test.clj
@@ -2,7 +2,6 @@
   (:require
     [clojure.test :refer [deftest are is]]
     [systems.bread.alpha.internal.query-inference :as i]
-    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.i18n :as i18n]))
 
 (deftest test-binding-pairs

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer [deftest are]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.test-helpers :refer [datastore->plugin

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -6,7 +6,7 @@
     [systems.bread.alpha.database :as store]
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.dispatcher :as dispatcher]
-    [systems.bread.alpha.test-helpers :refer [datastore->plugin
+    [systems.bread.alpha.test-helpers :refer [db->plugin
                                               plugins->loaded]]))
 
 (deftest test-create-post-ancestry-rule
@@ -61,7 +61,7 @@
 
 (deftest test-dispatch-post-queries
   (let [db ::FAKEDB
-        app (plugins->loaded [(datastore->plugin db)
+        app (plugins->loaded [(db->plugin db)
                               (i18n/plugin {:query-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)])

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer [deftest are]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.post :as post]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.test-helpers :refer [db->plugin
@@ -77,7 +77,7 @@
 
       ;; {:uri "/en/simple"}
       ;; i18n'd by default
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -102,7 +102,7 @@
 
       ;; {:uri "/en/one/two"}
       ;; Default key -> :post
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -127,7 +127,7 @@
 
       ;; {:uri "/en/one/two"}
       ;; Default key -> :post
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -151,7 +151,7 @@
        :route/params {:slugs "one/two" :lang "en"}}
 
       ;; {:uri "/en/one/two"}
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -175,7 +175,7 @@
        :route/params {:slugs "one/two" :lang "en"}}
 
       ;; {:uri "/en/one/two/three"}
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -201,7 +201,7 @@
 
       ;; {:uri "/en/simple"}
       ;; :translatable/fields alone only queries for :db/id, not :field/content
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -225,7 +225,7 @@
 
       ;; {:uri "/en/simple"}
       ;; :translatable/fields WITHOUT :field/content
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args
@@ -251,7 +251,7 @@
 
       ;; {:uri "/en"}
       ;; home page - no `slugs`
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :post
         :query/db db
         :query/args

--- a/test/core/systems/bread/alpha/taxon_test.clj
+++ b/test/core/systems/bread/alpha/taxon_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer [deftest are]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.taxon :as taxon]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.test-helpers :refer [db->plugin
@@ -27,7 +27,7 @@
 
       ;; {:uri "/en/by-taxon/category/some-tag"}
       ;; Not querying for any translatable content.
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :taxon
         :query/db db
         :query/args
@@ -47,7 +47,7 @@
 
       ;; {:uri "/en/tag/some-tag"}
       ;; :dispatcher.type/tag
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args
@@ -66,7 +66,7 @@
 
       ;; {:uri "/en/tag/some-tag"}
       ;; :post/type and :post/status have no effect without :post/_taxons
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args
@@ -87,7 +87,7 @@
 
       ;; {:uri "/en/by-taxon/category/some-tag"}
       ;; Query includes :taxon/field as a map.
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :taxon
         :query/db db
         :query/args
@@ -97,7 +97,7 @@
                    [?e0 :taxon/slug ?slug]]}
          :taxon.taxonomy/category
          "some-tag"]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:taxon :translatable/fields]
         :query/db db
         :query/args
@@ -119,7 +119,7 @@
 
       ;; {:uri "/en/tag/some-tag"}
       ;; Default :post/type and :post/status with :post/_taxons
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args
@@ -131,7 +131,7 @@
                    [?e0 :taxon/slug ?slug]]}
          :taxon.taxonomy/tag
          "some-tag"]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons]
         :query/db db
         :query/args
@@ -143,7 +143,7 @@
          [::bread/data :tag :db/id]
          :post.type/page
          :post.status/published]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons :translatable/fields]
         :query/db db
         :query/args
@@ -164,7 +164,7 @@
 
       ;; {:uri "/en/tag/some-tag"}
       ;; Custom :post/type and :post/status with :post/_taxons
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args
@@ -176,7 +176,7 @@
                    [?e0 :taxon/slug ?slug]]}
          :taxon.taxonomy/tag
          "some-tag"]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons]
         :query/db db
         :query/args
@@ -188,7 +188,7 @@
          [::bread/data :tag :db/id]
          :post.type/article
          :post.status/draft]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons :translatable/fields]
         :query/db db
         :query/args
@@ -211,7 +211,7 @@
 
       ;; {:uri "/en/tag/some-tag"}
       ;; :dispatcher.type/tag with :post/type and :post/status nil
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args
@@ -223,7 +223,7 @@
                    [?e0 :taxon/slug ?slug]]}
          :taxon.taxonomy/tag
          "some-tag"]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons]
         :query/db db
         :query/args
@@ -231,7 +231,7 @@
            :in [$ ?taxon]
            :where [[?post :post/taxons ?taxon]]}
          [::bread/data :tag :db/id]]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons :translatable/fields]
         :query/db db
         :query/args
@@ -254,7 +254,7 @@
 
       ;; {:uri "/en/tag/some-tag"}
       ;; :dispatcher.type/tag with :post/type and :post/status false
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args
@@ -266,7 +266,7 @@
                    [?e0 :taxon/slug ?slug]]}
          :taxon.taxonomy/tag
          "some-tag"]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons]
         :query/db db
         :query/args
@@ -274,7 +274,7 @@
            :in [$ ?taxon]
            :where [[?post :post/taxons ?taxon]]}
          [::bread/data :tag :db/id]]}
-       {:query/name ::store/query
+       {:query/name ::db/query
         :query/key [:tag :post/_taxons :translatable/fields]
         :query/db db
         :query/args
@@ -298,7 +298,7 @@
       ;; {:uri "/en/tag/some-tag"}
       ;; TODO Dynamic params from request...
       #_#_
-      [{:query/name ::store/query
+      [{:query/name ::db/query
         :query/key :tag
         :query/db db
         :query/args

--- a/test/core/systems/bread/alpha/taxon_test.clj
+++ b/test/core/systems/bread/alpha/taxon_test.clj
@@ -3,7 +3,7 @@
     [clojure.test :refer [deftest are]]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.taxon :as taxon]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.test-helpers :refer [datastore->plugin

--- a/test/core/systems/bread/alpha/taxon_test.clj
+++ b/test/core/systems/bread/alpha/taxon_test.clj
@@ -6,12 +6,12 @@
     [systems.bread.alpha.database :as store]
     [systems.bread.alpha.taxon :as taxon]
     [systems.bread.alpha.dispatcher :as dispatcher]
-    [systems.bread.alpha.test-helpers :refer [datastore->plugin
+    [systems.bread.alpha.test-helpers :refer [db->plugin
                                               plugins->loaded]]))
 
 (deftest test-dispatch-taxon-queries
   (let [db ::FAKEDB
-        app (plugins->loaded [(datastore->plugin db)
+        app (plugins->loaded [(db->plugin db)
                               (i18n/plugin {:query-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)])

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -22,13 +22,13 @@
   [_ {:keys [store]} _]
   store)
 
-(defn datastore->plugin [store]
+(defn db->plugin [store]
   {:hooks {:hook/datastore [{:action/name ::db
                              :action/description "Mock datastore"
                              :store store}]}})
 
 (defn datastore->loaded [store]
-  (plugins->loaded [(datastore->plugin store)]))
+  (plugins->loaded [(db->plugin store)]))
 
 (defn db-config->loaded [config]
   (-> config db-config->app bread/load-app))

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -49,13 +49,13 @@
 (defmacro use-datastore [freq config]
   `(t/use-fixtures ~freq (fn [f#]
                            (try
-                             (store/delete-database! ~config)
+                             (store/delete! ~config)
                              (catch Throwable e#
                                (log/warn (.getMessage e#))))
-                           (store/install! ~config)
-                           (store/connect! ~config)
+                           (store/create! ~config)
+                           (store/connect ~config)
                            (f#)
-                           (store/delete-database! ~config))))
+                           (store/delete! ~config))))
 
 (comment
   (macroexpand '(use-datastore :each {:my :config})))

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -46,7 +46,7 @@
   ([ks hooks]
    (map #(select-keys % ks) hooks)))
 
-(defmacro use-datastore [freq config]
+(defmacro use-db [freq config]
   `(t/use-fixtures ~freq (fn [f#]
                            (try
                              (store/delete! ~config)
@@ -58,7 +58,7 @@
                            (store/delete! ~config))))
 
 (comment
-  (macroexpand '(use-datastore :each {:my :config})))
+  (macroexpand '(use-db :each {:my :config})))
 
 (defn map->route-plugin [routes]
   "Takes a map m like:

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -24,7 +24,7 @@
 
 (defn db->plugin [db]
   {:hooks {::store/db [{:action/name ::db
-                        :action/description "Mock datastore"
+                        :action/description "Mock database"
                         :db db}]}
    ;; Configure a sensible connection object we can call (db conn) on.
    :config {:db/connection (reify

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -15,26 +15,26 @@
 (defn plugins->handler [plugins]
   (-> plugins plugins->app bread/load-handler))
 
-(defn datastore-config->app [config]
+(defn db-config->app [config]
   (plugins->app [(store/plugin config)]))
 
-(defmethod bread/action ::datastore
+(defmethod bread/action ::db
   [_ {:keys [store]} _]
   store)
 
 (defn datastore->plugin [store]
-  {:hooks {:hook/datastore [{:action/name ::datastore
+  {:hooks {:hook/datastore [{:action/name ::db
                              :action/description "Mock datastore"
                              :store store}]}})
 
 (defn datastore->loaded [store]
   (plugins->loaded [(datastore->plugin store)]))
 
-(defn datastore-config->loaded [config]
-  (-> config datastore-config->app bread/load-app))
+(defn db-config->loaded [config]
+  (-> config db-config->app bread/load-app))
 
-(defn datastore-config->handler [config]
-  (-> config datastore-config->app bread/load-handler))
+(defn db-config->handler [config]
+  (-> config db-config->app bread/load-handler))
 
 (defn distill-hooks
   "Returns a subset of the keys in each hook (map) in (the vector of) hooks.

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -19,13 +19,17 @@
   (plugins->app [(store/plugin config)]))
 
 (defmethod bread/action ::db
-  [_ {:keys [store]} _]
-  store)
+  [_ {:keys [db]} _]
+  db)
 
-(defn db->plugin [store]
+(defn db->plugin [db]
   {:hooks {::store/db [{:action/name ::db
                         :action/description "Mock datastore"
-                        :store store}]}})
+                        :db db}]}
+   ;; Configure a sensible connection object we can call (db conn) on.
+   :config {:db/connection (reify
+                             store/TransactionalDatabaseConnection
+                             (store/db [_] db))}})
 
 (defn datastore->loaded [store]
   (plugins->loaded [(db->plugin store)]))

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -31,9 +31,6 @@
                              store/TransactionalDatabaseConnection
                              (store/db [_] db))}})
 
-(defn datastore->loaded [store]
-  (plugins->loaded [(db->plugin store)]))
-
 (defn db-config->loaded [config]
   (-> config db-config->app bread/load-app))
 

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -4,7 +4,7 @@
     [clojure.test :as t]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.route :as route]
-    [systems.bread.alpha.datastore :as store]))
+    [systems.bread.alpha.database :as store]))
 
 (defn plugins->app [plugins]
   (bread/app {:plugins plugins}))

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -23,9 +23,9 @@
   store)
 
 (defn db->plugin [store]
-  {:hooks {:hook/datastore [{:action/name ::db
-                             :action/description "Mock datastore"
-                             :store store}]}})
+  {:hooks {::store/db [{:action/name ::db
+                        :action/description "Mock datastore"
+                        :store store}]}})
 
 (defn datastore->loaded [store]
   (plugins->loaded [(db->plugin store)]))

--- a/test/core/systems/bread/alpha/util_datalog_test.clj
+++ b/test/core/systems/bread/alpha/util_datalog_test.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.test :refer [deftest are is]]
     [systems.bread.alpha.util.datalog :as d]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.i18n :as i18n]))
 
 (deftest test-relation-reversed?

--- a/test/core/systems/bread/alpha/util_datalog_test.clj
+++ b/test/core/systems/bread/alpha/util_datalog_test.clj
@@ -2,7 +2,6 @@
   (:require
     [clojure.test :refer [deftest are is]]
     [systems.bread.alpha.util.datalog :as d]
-    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.i18n :as i18n]))
 
 (deftest test-relation-reversed?

--- a/tools/systems/bread/alpha/tools/debug/core.clj
+++ b/tools/systems/bread/alpha/tools/debug/core.clj
@@ -6,7 +6,7 @@
     [clojure.tools.logging :as log]
     [clojure.walk :as walk]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.database :as store]
+    [systems.bread.alpha.database :as db]
     [systems.bread.alpha.tools.protocols]
     [systems.bread.alpha.tools.debug.server :as srv])
   (:import
@@ -32,14 +32,14 @@
          :request/uuid (str uuid)
          :request/millis (.getTime (Date.))
          ;; TODO support extending these fields via metadata
-         :request/database (store/database req)))
+         :request/database (db/database req)))
 
 (defmethod event-data :profile.type/response
   [[_ {uuid :request/uuid :as res}]]
   (assoc res
          :request/uuid (str uuid)
          ;; TODO compute duration?
-         :response/database (store/database res)))
+         :response/database (db/database res)))
 
 (defmethod event-data :profile.type/hook
   [[_ {:keys [hook args app f result millis]
@@ -122,7 +122,7 @@
   (let [;; TODO parameterize getting IDs
         rid (UUID/randomUUID)
         as-of-param (bread/config req :db/as-of-param)
-        as-of (or (store/timepoint req) (store/max-tx req))
+        as-of (or (db/timepoint req) (db/max-tx req))
         req (assoc req
                    :profiler/profiled? true
                    :profiler/as-of-param as-of-param

--- a/tools/systems/bread/alpha/tools/debug/core.clj
+++ b/tools/systems/bread/alpha/tools/debug/core.clj
@@ -6,7 +6,7 @@
     [clojure.tools.logging :as log]
     [clojure.walk :as walk]
     [systems.bread.alpha.core :as bread]
-    [systems.bread.alpha.datastore :as store]
+    [systems.bread.alpha.database :as store]
     [systems.bread.alpha.tools.protocols]
     [systems.bread.alpha.tools.debug.server :as srv])
   (:import

--- a/tools/systems/bread/alpha/tools/debug/core.clj
+++ b/tools/systems/bread/alpha/tools/debug/core.clj
@@ -32,14 +32,14 @@
          :request/uuid (str uuid)
          :request/millis (.getTime (Date.))
          ;; TODO support extending these fields via metadata
-         :request/datastore (store/datastore req)))
+         :request/database (store/database req)))
 
 (defmethod event-data :profile.type/response
   [[_ {uuid :request/uuid :as res}]]
   (assoc res
          :request/uuid (str uuid)
          ;; TODO compute duration?
-         :response/datastore (store/datastore res)))
+         :response/database (store/database res)))
 
 (defmethod event-data :profile.type/hook
   [[_ {:keys [hook args app f result millis]

--- a/tools/systems/bread/alpha/tools/debug/core.clj
+++ b/tools/systems/bread/alpha/tools/debug/core.clj
@@ -121,7 +121,7 @@
   ;; TODO support passing a in a fn for filtering request data
   (let [;; TODO parameterize getting IDs
         rid (UUID/randomUUID)
-        as-of-param (bread/config req :datastore/as-of-param)
+        as-of-param (bread/config req :db/as-of-param)
         as-of (or (store/timepoint req) (store/max-tx req))
         req (assoc req
                    :profiler/profiled? true

--- a/tools/systems/bread/alpha/tools/debug/diff.cljs
+++ b/tools/systems/bread/alpha/tools/debug/diff.cljs
@@ -14,11 +14,11 @@
   (get-in @db [:request/uuid uuid]))
 
 (defn- uuid->max-tx [uuid]
-  (-> uuid uuid->req (get-in [:request/response :response/datastore :max-tx])))
+  (-> uuid uuid->req (get-in [:request/response :response/database :max-tx])))
 
 (def ^:private type->path
   {:response-pre-render [:response/pre-render]
-   :database [:request/response :response/datastore]})
+   :database [:request/response :response/database]})
 
 (defn- diff-entities [[a b] diff-type]
   (when (and a b)

--- a/tools/systems/bread/alpha/tools/pprint.cljc
+++ b/tools/systems/bread/alpha/tools/pprint.cljc
@@ -3,7 +3,7 @@
     [clojure.string :as string :refer [split starts-with?]]
     [systems.bread.alpha.core :as core]
     [systems.bread.alpha.cache]
-    [systems.bread.alpha.database :as store])
+    [systems.bread.alpha.database :as db])
   (:import
     [clojure.lang Keyword]
     [java.io Writer]))
@@ -24,7 +24,7 @@
 
 (defmethod print-method :bread/migration [migration writer]
   (.write writer (if *summarize-migrations*
-                   (let [nm (or (store/migration-key migration)
+                   (let [nm (or (db/migration-key migration)
                                 (hash migration))
                          summary {:tx-count (count migration)}]
                      (str "#migration[" summary " " nm "]"))

--- a/tools/systems/bread/alpha/tools/pprint.cljc
+++ b/tools/systems/bread/alpha/tools/pprint.cljc
@@ -3,7 +3,7 @@
     [clojure.string :as string :refer [split starts-with?]]
     [systems.bread.alpha.core :as core]
     [systems.bread.alpha.cache]
-    [systems.bread.alpha.datastore :as store])
+    [systems.bread.alpha.database :as store])
   (:import
     [clojure.lang Keyword]
     [java.io Writer]))


### PR DESCRIPTION
Addresses #67 

This PR also:
- renames `datastore` to `database` and uses the ns alias `db` instead of `store`
- updates a bunch of `:datastore/*` keywords to `:db/*`