### PR TITLE
Bugfix: post-ancestry rule

### DIFF
--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -221,6 +221,9 @@
 
   (response ((:bread/handler @system) {:uri "/en"}))
   (response ((:bread/handler @system) {:uri "/en/hello"}))
+  (response ((:bread/handler @system) {:uri "/en/hello/child-page"}))
+  ;; This should 404:
+  (response ((:bread/handler @system) {:uri "/en/child-page"}))
 
   (response ((:bread/handler @system) {:uri "/login"}))
   (response ((:bread/handler @system) {:uri "/login"
@@ -250,6 +253,24 @@
     (bread/hook $ ::bread/expand)
     (bread/hook $ ::bread/render)
     (select-keys $ [:status :body :headers]))
+
+  (bread/query {:query/name :systems.bread.alpha.database/query,
+                :query/key :post,
+                :query/db (db/database (->app $req)) ,
+                :query/args
+                ['{:find [(pull ?e (:db/id :post/slug :post/type :post/status)) .],
+                   :in [$ % ?slug_0 ?type ?status],
+                   :where
+                   [(post-ancestry ?e ?slug_0)
+                    [?e :post/type ?type]
+                    [?e :post/status ?status]]}
+                 '[[(post-ancestry ?child ?slug_0)
+                    [?child :post/slug ?slug_0]
+                    (not-join [?child] [?_ :post/children ?child])]]
+                 "child-page"
+                 :post.type/page
+                 :post.status/published]}
+               {})
 
   (defn q [& args]
     (apply

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -220,16 +220,18 @@
                                         :request-method :post})
 
   (response ((:bread/handler @system) {:uri "/en"}))
+  (response ((:bread/handler @system) {:uri "/en/hello"}))
+
   (response ((:bread/handler @system) {:uri "/login"}))
   (response ((:bread/handler @system) {:uri "/login"
                                        :request-method :post
                                        :params {:username "coby"
                                                 :password "hello"}}))
-  (response ((:bread/handler @system) {:uri "/en/page"}))
 
   (defn ->app [req]
     (when-let [app (:bread/app @system)] (merge app req)))
   (def $req {:uri "/en"})
+  (def $req {:uri "/en/hello"})
   (as-> (->app $req) $
     (bread/hook $ ::bread/route)
     (::bread/dispatcher $))

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -38,6 +38,70 @@
                 #{{:ability/key :publish-posts}
                   {:ability/key :edit-posts}
                   {:ability/key :delete-posts}}}}}
+            {:db/id "hello"
+             :post/slug "hello"
+             :post/type :post.type/page
+             :post/status :post.status/published
+             :post/children #{"child-page"}
+             :translatable/fields
+             [{:field/key :a
+               :field/content "A"
+               :field/lang :en}
+              {:field/key :a
+               :field/content "___"
+               :field/lang :es}
+              {:field/key :b
+               :field/content "B"
+               :field/lang :en}
+              {:field/key :other
+               :field/content "other"
+               :field/lang :es}]}
+            {:db/id "child-page"
+             :post/slug "child-page"
+             :post/type :post.type/page
+             :post/status :post.status/published
+             :translatable/fields
+             [{:field/key :a
+               :field/content "A"
+               :field/lang :en}
+              {:field/key :a
+               :field/content "___"
+               :field/lang :es}
+              {:field/key :b
+               :field/content "B"
+               :field/lang :en}
+              {:field/key :other
+               :field/content "other"
+               :field/lang :es}]}
+            {:db/id "my-item"
+             :post/type :post.type/menu-item
+             :translatable/fields
+             [{:field/key :a
+               :field/content "A"
+               :field/lang :en}
+              {:field/key :a
+               :field/content "___"
+               :field/lang :es}
+              {:field/key :b
+               :field/content "B"
+               :field/lang :en}
+              {:field/key :other
+               :field/content "other"
+               :field/lang :es}]}
+            #_
+            [:db/id
+             {:menu/items
+              [:db/id
+               {:translatable/fields
+                [:field/key :field/content]}
+               {:menu.item/entities
+                [{:translatable/fields
+                  [:field/key :field/content]}]}]}]
+            {:menu/key :main-nav
+             :menu/items [{:menu.item/entity "hello"
+                           :menu.item/order 0}
+                          {:menu.item/entity "my-item"
+                           :menu.item/order 1}]}
             ]]}
  :bread/router
  #reitit/router

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -23,7 +23,7 @@
   :force? true
   :db/migrations #deref #var systems.bread.alpha.schema/initial
   :db/initial-txns
-  #concat [#deref #var systems.bread.alpha.cms.defaults/initial-data
+  #concat [#deref #var systems.bread.alpha.plugin.defaults/initial-data
            [{:user/username "coby"
              :user/name "Coby Tamayo"
              :user/email "coby@bread.systems"

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -41,7 +41,7 @@
                                       (butlast descendant-syms)
                                       (rest slug-syms))))
            [(list 'not-join [earliest-ancestor-sym]
-                  ['?_ :post/parent earliest-ancestor-sym])]))))
+                  ['?_ :post/children earliest-ancestor-sym])]))))
 
 (defn- ancestralize [query slugs]
   (let [depth (count slugs)

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -16,14 +16,14 @@
 
     '[(post-ancestry ?child ?slug_0)
       [?child :post/slug ?slug_0]
-      (not-join [?child] [?_ :post/parent ?child])]
+      (not-join [?child] [?_ :post/children ?child])]
     [1]
 
     '[(post-ancestry ?child ?slug_0 ?slug_1)
       [?child :post/slug ?slug_0]
       [?ancestor_1 :post/children ?child]
       [?ancestor_1 :post/slug ?slug_1]
-      (not-join [?ancestor_1] [?_ :post/parent ?ancestor_1])]
+      (not-join [?ancestor_1] [?_ :post/children ?ancestor_1])]
     [2]
 
     '[(post-ancestry ?child ?slug_0 ?slug_1 ?slug_2)
@@ -32,7 +32,7 @@
       [?ancestor_1 :post/slug ?slug_1]
       [?ancestor_2 :post/children ?ancestor_1]
       [?ancestor_2 :post/slug ?slug_2]
-      (not-join [?ancestor_2] [?_ :post/parent ?ancestor_2])]
+      (not-join [?ancestor_2] [?_ :post/children ?ancestor_2])]
     [3]
 
     '[(post-ancestry ?child ?slug_0 ?slug_1 ?slug_2 ?slug_3)
@@ -43,7 +43,7 @@
       [?ancestor_2 :post/slug ?slug_2]
       [?ancestor_3 :post/children ?ancestor_2]
       [?ancestor_3 :post/slug ?slug_3]
-      (not-join [?ancestor_3] [?_ :post/parent ?ancestor_3])]
+      (not-join [?ancestor_3] [?_ :post/children ?ancestor_3])]
     [4]
 
     '[(post-ancestry ?child ?slug_0 ?slug_1 ?slug_2 ?slug_3 ?slug_4)
@@ -56,7 +56,7 @@
       [?ancestor_3 :post/slug ?slug_3]
       [?ancestor_4 :post/children ?ancestor_3]
       [?ancestor_4 :post/slug ?slug_4]
-      (not-join [?ancestor_4] [?_ :post/parent ?ancestor_4])]
+      (not-join [?ancestor_4] [?_ :post/children ?ancestor_4])]
     [5]))
 
 (deftest test-dispatch-post-queries


### PR DESCRIPTION
The final clause in the `post-ancestry` rule was a `not-join` on the non-existent `:post/parent` attribute, which was superceded by `:post/children`. Therefore the `not-join` was always satifying, allowing child pages to be accessible at top-level routes.