### PR TITLE
simplify Router API

### DIFF
--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -347,14 +347,6 @@
      #{:post.status/published})
 
   (slurp (io/resource "public/assets/hi.txt"))
-  (bread/match (:bread/router @system) {:uri "/assets/hi.txt"
-                                        :request-method :get})
-  (bread/match (:bread/router @system) {:uri "/en"
-                                        :request-method :get})
-  (bread/match (:bread/router @system) {:uri "/login"
-                                        :request-method :get})
-  (bread/match (:bread/router @system) {:uri "/login"
-                                        :request-method :post})
 
   (response ((:bread/handler @system) {:uri "/en"}))
   (response ((:bread/handler @system) {:uri "/en/hello"}))
@@ -443,8 +435,6 @@
     (reitit/match-by-name $router :page {:field/lang :en :thing/slug* "x"}))
 
   (bread/routes $router)
-  (let [req (->app $req)]
-    (bread/match (route/router req) req))
   (bread/route-params $router $req)
 
   ;; route/uri infers params and then just calls bread/path under the hood...

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -445,7 +445,7 @@
   (bread/routes $router)
   (let [req (->app $req)]
     (bread/match (route/router req) req))
-  (bread/params $router (bread/match $router $req))
+  (bread/route-params $router $req)
 
   ;; route/uri infers params and then just calls bread/path under the hood...
   (bread/path $router :page {:field/lang :en :thing/slug* "a/b/c"})

--- a/plugins/bidi/systems/bread/alpha/plugin/bidi.cljc
+++ b/plugins/bidi/systems/bread/alpha/plugin/bidi.cljc
@@ -8,8 +8,6 @@
   (bread/path [this route-name params]
     (let [params (interleave (keys params) (vals params))]
       (apply bidi/path-for routes route-name params)))
-  (bread/dispatcher [this match]
-    (get dispatchers (:handler match)))
   (bread/params [this match]
     (:route-params match))
   (bread/routes [this]

--- a/plugins/bidi/systems/bread/alpha/plugin/bidi.cljc
+++ b/plugins/bidi/systems/bread/alpha/plugin/bidi.cljc
@@ -8,10 +8,6 @@
   (bread/path [this route-name params]
     (let [params (interleave (keys params) (vals params))]
       (apply bidi/path-for routes route-name params)))
-  (bread/match [this req]
-    (let [ks (filter (complement namespace) (keys req))
-          options (interleave ks (map req ks))]
-      (apply bidi/match-route routes (:uri req) options)))
   (bread/dispatcher [this match]
     (get dispatchers (:handler match)))
   (bread/params [this match]
@@ -29,14 +25,7 @@
 
   (c/match {::bread/dispatcher {:dispatcher/component :THIS}})
 
-  (let [router (BidiRouter. $routes $dispatchers)]
-    (for [route ["/en" "/en/abc" "/en/abc/xyz" "/en/blog" "/en/blog/qwerty"]]
-      (let [match (bread/match router {:uri route})]
-        [route (bread/dispatcher router match) (bread/params router match)])))
-
   (bidi/match-route $routes "/en")
-  (let [router (BidiRouter. $routes {})]
-    (bread/match router {:uri "/en"}))
 
   (do
     (def $routes

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -59,9 +59,9 @@
               ;; Decode the URL-/dash-encoded string.
               (string/replace #"-%2F" "/"))))
   (bread/match [router req]
-    (reitit/match-by-path router (:uri req)))
-  (bread/route-spec [router match]
-    (template->spec (:template match)))
+    (throw (Exception. "match is deprecated")))
+  (bread/route-spec [router req]
+    (->> req :uri (reitit/match-by-path router) :template template->spec))
   (bread/params [router match]
     (:path-params match))
   (bread/params* [router req]

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -68,7 +68,7 @@
     (some->> req :uri (reitit/match-by-path router) :path-params))
   (bread/dispatcher [router match]
     (:data match))
-  (bread/dispatcher* [router req]
+  (bread/route-dispatcher [router req]
     (let [method (:request-method req)
           match-data (some->> req :uri (reitit/match-by-path router) :data)]
       (if-let [handler (-> match-data (get method) :handler)] handler match-data)))

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -58,8 +58,6 @@
               reitit/match->path
               ;; Decode the URL-/dash-encoded string.
               (string/replace #"-%2F" "/"))))
-  (bread/match [router req]
-    (throw (Exception. "match is deprecated")))
   (bread/route-spec [router req]
     (->> req :uri (reitit/match-by-path router) :template template->spec))
   (bread/route-params [router req]

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -34,6 +34,7 @@
          ctx {:keyword? false}]
     (case c
       nil params
+      ;; TODO support keyword-style :route/:params syntax
       \{ (recur cs "" params {:keyword? true})
       \} (recur cs "" (conj params (keyword param)) {:keyword? false})
       \/ (let [param? (seq param)
@@ -49,7 +50,6 @@
 
 (extend-protocol Router
   reitit.core.Router
-  ;; TODO route-name
   (bread/path [router route-name params]
     (let [;; Dash-encode all string params
           params (into {} (map (juxt key (comp dash-encode val)) params))]
@@ -68,6 +68,5 @@
       (if-let [handler (-> match-data (get method) :handler)] handler match-data)))
   (bread/routes [router]
     (into {} (map (fn [[template route]]
-                    [(route-name route)
-                     (assoc route :template template)])
+                    [(route-name route) (assoc route :template template)])
                   (reitit/compiled-routes router)))))

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -62,8 +62,6 @@
     (->> req :uri (reitit/match-by-path router) :template template->spec))
   (bread/route-params [router req]
     (some->> req :uri (reitit/match-by-path router) :path-params))
-  (bread/dispatcher [router match]
-    (:data match))
   (bread/route-dispatcher [router req]
     (let [method (:request-method req)
           match-data (some->> req :uri (reitit/match-by-path router) :data)]

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -62,8 +62,6 @@
     (throw (Exception. "match is deprecated")))
   (bread/route-spec [router req]
     (->> req :uri (reitit/match-by-path router) :template template->spec))
-  (bread/params [router match]
-    (:path-params match))
   (bread/route-params [router req]
     (some->> req :uri (reitit/match-by-path router) :path-params))
   (bread/dispatcher [router match]

--- a/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
+++ b/plugins/reitit/systems/bread/alpha/plugin/reitit.cljc
@@ -64,7 +64,7 @@
     (->> req :uri (reitit/match-by-path router) :template template->spec))
   (bread/params [router match]
     (:path-params match))
-  (bread/params* [router req]
+  (bread/route-params [router req]
     (some->> req :uri (reitit/match-by-path router) :path-params))
   (bread/dispatcher [router match]
     (:data match))

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -29,7 +29,7 @@
   (params [this match])
   (route-params [this req])
   (dispatcher [this match])
-  (dispatcher* [this req])
+  (route-dispatcher [this req])
   (routes [this]))
 
 (defprotocol WatchableRoute

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -24,9 +24,7 @@
 (defprotocol Router
   :extend-via-metadata true
   (path [this route-name params])
-  (match [this req])
   (route-spec [this match])
-  (params [this match])
   (route-params [this req])
   (dispatcher [this match])
   (route-dispatcher [this req])

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -26,7 +26,6 @@
   (path [this route-name params])
   (route-spec [this req])
   (route-params [this req])
-  (dispatcher [this match])
   (route-dispatcher [this req])
   (routes [this]))
 

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -27,7 +27,7 @@
   (match [this req])
   (route-spec [this match])
   (params [this match])
-  (params* [this req])
+  (route-params [this req])
   (dispatcher [this match])
   (dispatcher* [this req])
   (routes [this]))

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -27,7 +27,9 @@
   (match [this req])
   (route-spec [this match])
   (params [this match])
+  (params* [this req])
   (dispatcher [this match])
+  (dispatcher* [this req])
   (routes [this]))
 
 (defprotocol WatchableRoute

--- a/src/systems/bread/alpha/core.cljc
+++ b/src/systems/bread/alpha/core.cljc
@@ -24,7 +24,7 @@
 (defprotocol Router
   :extend-via-metadata true
   (path [this route-name params])
-  (route-spec [this match])
+  (route-spec [this req])
   (route-params [this req])
   (dispatcher [this match])
   (route-dispatcher [this req])

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -20,7 +20,7 @@
 (defn lang
   "High-level fn for getting the language for the current request."
   [req]
-  (let [params (bread/params* (route/router req) req)
+  (let [params (bread/route-params (route/router req) req)
         lang-param (bread/config req :i18n/lang-param)
         supported (get (supported-langs req) (keyword (lang-param params)))
         fallback (bread/config req :i18n/fallback-lang)

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -20,7 +20,7 @@
 (defn lang
   "High-level fn for getting the language for the current request."
   [req]
-  (let [params (route/params req (route/match req))
+  (let [params (bread/params* (route/router req) req)
         lang-param (bread/config req :i18n/lang-param)
         supported (get (supported-langs req) (keyword (lang-param params)))
         fallback (bread/config req :i18n/fallback-lang)

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -100,7 +100,7 @@
         :expansion/description "Process post menu item data."
         :router (route/router req)
         :route/name route-name
-        :route/params (route/params req (route/match req))
+        :route/params (route/params req (route/match req)) ;; TODO
         :field/key (field-keys fks)
         :sort-by sort-key}])))
 

--- a/src/systems/bread/alpha/navigation.cljc
+++ b/src/systems/bread/alpha/navigation.cljc
@@ -100,7 +100,7 @@
         :expansion/description "Process post menu item data."
         :router (route/router req)
         :route/name route-name
-        :route/params (route/params req (route/match req)) ;; TODO
+        :route/params (bread/route-params (route/router req) req)
         :field/key (field-keys fks)
         :sort-by sort-key}])))
 
@@ -149,7 +149,7 @@
         :sort-by sort-key
         :router (route/router req)
         :route/name route-name
-        :route/params (route/params req (route/match req))}])))
+        :route/params (bread/route-params (route/router req) req)}])))
 
 (defmethod menu-expansions ::global
   menu-expansions?type=global
@@ -196,7 +196,7 @@
         :sort-by sort-key
         :router (route/router req)
         :route/name route-name
-        :route/params (route/params req (route/match req))}])))
+        :route/params (bread/route-params (route/router req) req)}])))
 
 (defmethod menu-expansions ::location
   menu-expansions?type=location
@@ -244,7 +244,7 @@
         :sort-by sort-key
         :router (route/router req)
         :route/name route-name
-        :route/params (route/params req (route/match req))}])))
+        :route/params (bread/route-params (route/router req) req)}])))
 
 (defmethod bread/action ::add-menu-expansions
   add-menu-expansions-action

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -75,7 +75,7 @@
         route-keys (filter keyword? (bread/route-spec router route))]
     (zipmap route-keys (map #( bread/infer-param % route-data) route-keys))))
 
-(defmethod bread/action ::uri [req {router :router} [_ route-name thing]]
+(defmethod bread/action ::uri [req {:keys [router]} [_ route-name thing]]
   (->> thing
        (merge (bread/route-params router req))
        (path-params router route-name)

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -19,6 +19,10 @@
 (defn params [req match]
   (bread/hook req ::params nil match))
 
+(defn router [app]
+  "Returns the Router configured for the given app"
+  (bread/hook app ::router nil))
+
 (defn dispatcher [req]
   "Get the full dispatcher for the given request. Router implementations should
   call this function."
@@ -73,10 +77,6 @@
 (defmethod bread/action ::dispatch
   [req _ _]
   (assoc req ::bread/dispatcher (dispatcher req)))
-
-(defn router [app]
-  "Returns the Router configured for the given app"
-  (bread/hook app ::router nil))
 
 (defn path-params [router route-name route-data]
   (let [;; OK, so turns out we still need to EITHER:

--- a/src/systems/bread/alpha/route.cljc
+++ b/src/systems/bread/alpha/route.cljc
@@ -54,10 +54,6 @@
   [_ {:keys [router]} [_path route-name params]]
   (bread/path router route-name params))
 
-(defmethod bread/action ::match
-  [req {:keys [router]} _]
-  (bread/match router req))
-
 (defmethod bread/action ::params
   [req {:keys [router]} _]
   (bread/route-params router req))

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -184,8 +184,6 @@
           router (reify bread/Router
                    (bread/match [router req]
                      (get routes (:uri req)))
-                   (bread/params [router match]
-                     (:route/params match))
                    (bread/route-params [router req]
                      (:route/params (get routes (:uri req))))
                    (bread/dispatcher [router match]

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -187,11 +187,11 @@
                    (bread/params [router match]
                      (:route/params match))
                    (bread/route-params [router req]
-                     (naive-params (:uri req)))
+                     (:route/params (get routes (:uri req))))
                    (bread/dispatcher [router match]
                      (:bread/dispatcher match))
                    (bread/route-dispatcher [router req]
-                     (get routes (:uri req))))
+                     (:bread/dispatcher (get routes (:uri req)))))
           plugins (defaults/plugins
                     {:db config
                      :components {:not-found not-found}

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -184,8 +184,6 @@
           router (reify bread/Router
                    (bread/route-params [router req]
                      (:route/params (get routes (:uri req))))
-                   (bread/dispatcher [router match]
-                     (:bread/dispatcher match))
                    (bread/route-dispatcher [router req]
                      (:bread/dispatcher (get routes (:uri req)))))
           plugins (defaults/plugins

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -186,7 +186,7 @@
                      (get routes (:uri req)))
                    (bread/params [router match]
                      (:route/params match))
-                   (bread/params* [router req]
+                   (bread/route-params [router req]
                      (naive-params (:uri req)))
                    (bread/dispatcher [router match]
                      (:bread/dispatcher match)))

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -182,8 +182,6 @@
                    :route/params {:field/lang "fr"
                                   :thing/slug* "not-found"}}}
           router (reify bread/Router
-                   (bread/match [router req]
-                     (get routes (:uri req)))
                    (bread/route-params [router req]
                      (:route/params (get routes (:uri req))))
                    (bread/dispatcher [router match]

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -189,7 +189,9 @@
                    (bread/route-params [router req]
                      (naive-params (:uri req)))
                    (bread/dispatcher [router match]
-                     (:bread/dispatcher match)))
+                     (:bread/dispatcher match))
+                   (bread/route-dispatcher [router req]
+                     (get routes (:uri req))))
           plugins (defaults/plugins
                     {:db config
                      :components {:not-found not-found}

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -10,7 +10,7 @@
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.route :as route]
     [systems.bread.alpha.schema :as schema]
-    [systems.bread.alpha.test-helpers :refer [use-db]]
+    [systems.bread.alpha.test-helpers :refer [naive-params use-db]]
     [systems.bread.alpha.defaults :as defaults]))
 
 (def config {:db/type :datahike
@@ -186,6 +186,8 @@
                      (get routes (:uri req)))
                    (bread/params [router match]
                      (:route/params match))
+                   (bread/params* [router req]
+                     (naive-params (:uri req)))
                    (bread/dispatcher [router match]
                      (:bread/dispatcher match)))
           plugins (defaults/plugins

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -8,9 +8,11 @@
     [systems.bread.alpha.defaults :as defaults]
     [systems.bread.alpha.database :as db]
     [systems.bread.alpha.internal.time :as t]
+    [systems.bread.alpha.route :as route]
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.plugin.auth :as auth]
-    [systems.bread.alpha.test-helpers :refer [plugins->loaded
+    [systems.bread.alpha.test-helpers :refer [naive-router
+                                              plugins->loaded
                                               plugins->handler
                                               use-db]])
   (:import
@@ -65,6 +67,7 @@
                       (conj
                         (defaults/plugins {:db config
                                            :routes false})
+                        (route/plugin {:router (naive-router)})
                         {:hooks
                          {::bread/route
                           [{:action/name ::route

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -27,6 +27,30 @@
     ;;
     ))
 
+(deftest test-params*
+  (are
+    [expected routes req]
+    (= expected (bread/params* (reitit/router routes) req))
+
+    nil nil {}
+    nil [] {}
+    nil ["/:slug" {:name :post}] {}
+
+    {:slug "abc"}
+    [["/:slug" {:name :post}]]
+    {:uri "/abc"}
+
+    {:slug "xyz"}
+    [["/:slug" {:name :post}]]
+    {:uri "/xyz"}
+
+    {:field/lang "en" :thing/slug "xyz"}
+    [["/{field/lang}/{thing/slug}" {:name :post}]]
+    {:uri "/en/xyz"}
+
+    ;;
+    ))
+
 (deftest test-match
   (are
     [expected routes uri]
@@ -113,6 +137,39 @@
     {:name ::page :dispatcher/type ::page}
     []
     {:data {:name ::page :dispatcher/type ::page}}
+
+    ;;
+    ))
+
+(deftest test-dispatcher*
+  (are
+    [expected routes req]
+    (= expected (let [router (reitit/router routes)]
+                  (bread/dispatcher* router req)))
+
+    nil nil nil
+    nil nil {}
+    nil [] {}
+    nil ["/:slug" {:name :page}] nil
+    nil ["/:slug" {:name :page}] {}
+
+    {:name :page}
+    ["/:slug" {:name :page}]
+    {:uri "/:slug"}
+
+    {:name :page}
+    ["/:slug" {:name :page}]
+    {:uri "/:slug" :request-method :get}
+
+    {:name :GET}
+    ["/:slug" {:get {:handler {:name :GET}}
+               :post {:handler {:name :POST}}}]
+    {:uri "/:slug" :request-method :get}
+
+    {:name :POST}
+    ["/:slug" {:get {:handler {:name :GET}}
+               :post {:handler {:name :POST}}}]
+    {:uri "/:slug" :request-method :post}
 
     ;;
     ))

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -29,39 +29,6 @@
     ;;
     ))
 
-#_
-(deftest test-match
-  (are
-    [expected routes uri]
-    (= (when expected
-         (reitit/map->Match expected))
-       (let [router (reitit/router routes)]
-         (bread/match router {:uri uri})))
-
-    nil nil ""
-    nil [] ""
-    nil ["/:slug" {:name :post}] ""
-    nil ["/:slug" {:name :post}] "/"
-
-    {:data {:name :post}
-     :path "/abc"
-     :path-params {:slug "abc"}
-     :template "/:slug"
-     :result nil}
-    ["/:slug" {:name :post}]
-    "/abc"
-
-    {:data {:name :post}
-     :path "/a/b/c"
-     :path-params {:slug "a/b/c"}
-     :template "/{*slug}"
-     :result nil}
-    ["/{*slug}" {:name :post}]
-    "/a/b/c"
-
-    ;;
-    ))
-
 (deftest test-route-spec
   (are
     [expected routes uri]

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -27,10 +27,10 @@
     ;;
     ))
 
-(deftest test-params*
+(deftest test-route-params
   (are
     [expected routes req]
-    (= expected (bread/params* (reitit/router routes) req))
+    (= expected (bread/route-params (reitit/router routes) req))
 
     nil nil {}
     nil [] {}

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -142,11 +142,11 @@
     ;;
     ))
 
-(deftest test-dispatcher*
+(deftest test-route-dispatcher
   (are
     [expected routes req]
     (= expected (let [router (reitit/router routes)]
-                  (bread/dispatcher* router req)))
+                  (bread/route-dispatcher router req)))
 
     nil nil nil
     nil nil {}

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -64,29 +64,6 @@
     ;;
     ))
 
-(deftest test-dispatcher
-  (are
-    [expected routes match]
-    (= expected (let [router (reitit/router routes)]
-                  (bread/dispatcher router match)))
-
-    nil nil nil
-    nil nil {}
-    nil [] {}
-    nil ["/:slug" {:name :post}] nil
-    nil ["/:slug" {:name :post}] {}
-
-    {:name :x}
-    []
-    {:data {:name :x}}
-
-    {:name ::page :dispatcher/type ::page}
-    []
-    {:data {:name ::page :dispatcher/type ::page}}
-
-    ;;
-    ))
-
 (deftest test-route-dispatcher
   (are
     [expected routes req]

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -51,6 +51,7 @@
     ;;
     ))
 
+#_
 (deftest test-match
   (are
     [expected routes uri]
@@ -88,7 +89,7 @@
     [expected routes uri]
     (= expected
        (let [router (reitit/router routes)]
-         (bread/route-spec router (bread/match router {:uri uri}))))
+         (bread/route-spec router {:uri uri})))
 
     [] nil ""
     [] [] ""

--- a/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
+++ b/test/cms/systems/bread/alpha/plugin_reitit_router_test.clj
@@ -5,28 +5,6 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.plugin.reitit]))
 
-(deftest test-params
-  (are
-    [expected routes match]
-    (= expected (let [router (reitit/router routes)]
-                  (bread/params router match)))
-
-    nil nil {}
-    nil [] {}
-    nil [] {:thing/slug "x"}
-    nil ["/:slug" {:name :post}] {}
-
-    {:slug "abc"}
-    [["/:slug" {:name :post}]]
-    {:path-params {:slug "abc"}}
-
-    {:slug "xyz" :lang :en}
-    [["/:slug" {:name :post}]]
-    {:path-params {:slug "xyz" :lang :en}}
-
-    ;;
-    ))
-
 (deftest test-route-params
   (are
     [expected routes req]

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -125,7 +125,7 @@
   (let [app (plugins->loaded [(db/plugin config)
                               (i18n/plugin {:supported-langs #{:en :es}})
                               (expansion/plugin)
-                              naive-plugin])]
+                              (route/plugin {:router $naive-router})])]
     (are
       [strings uri]
       (= strings (get-in ((bread/handler app) {:uri uri})
@@ -196,6 +196,7 @@
                                     :query-strings? false
                                     :format-fields? format-fields?
                                     :compact-fields? compact-fields?})
+                      (route/plugin {:router $naive-router})
                       ;; Set up an ad-hoc plugin to hard-code lang.
                       {:hooks
                        {::i18n/lang [{:action/name ::bread/value

--- a/test/core/systems/bread/alpha/navigation_test.clj
+++ b/test/core/systems/bread/alpha/navigation_test.clj
@@ -14,7 +14,6 @@
 
 (defrecord MockRouter [params]
   bread/Router
-  (bread/params [this _] params)
   (bread/route-params [this _] params)
   (bread/match [this _])
   (bread/route-spec [this match]

--- a/test/core/systems/bread/alpha/navigation_test.clj
+++ b/test/core/systems/bread/alpha/navigation_test.clj
@@ -15,6 +15,7 @@
 (defrecord MockRouter [params]
   bread/Router
   (bread/params [this _] params)
+  (bread/params* [this _] params)
   (bread/match [this _])
   (bread/route-spec [this match]
     [:field/lang :thing/slug*])

--- a/test/core/systems/bread/alpha/navigation_test.clj
+++ b/test/core/systems/bread/alpha/navigation_test.clj
@@ -15,8 +15,7 @@
 (defrecord MockRouter [params]
   bread/Router
   (bread/route-params [this _] params)
-  (bread/match [this _])
-  (bread/route-spec [this match]
+  (bread/route-spec [this _]
     [:field/lang :thing/slug*])
   (bread/path [this route-name params]
     (let [route (get {::page [:field/lang :thing/slug*]} route-name)]

--- a/test/core/systems/bread/alpha/navigation_test.clj
+++ b/test/core/systems/bread/alpha/navigation_test.clj
@@ -15,7 +15,7 @@
 (defrecord MockRouter [params]
   bread/Router
   (bread/params [this _] params)
-  (bread/params* [this _] params)
+  (bread/route-params [this _] params)
   (bread/match [this _])
   (bread/route-spec [this match]
     [:field/lang :thing/slug*])

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -5,8 +5,10 @@
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.database :as db]
     [systems.bread.alpha.post :as post]
+    [systems.bread.alpha.route :as route]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.test-helpers :refer [db->plugin
+                                              naive-router
                                               plugins->loaded]]))
 
 (deftest test-create-post-ancestry-rule
@@ -66,6 +68,7 @@
                               (i18n/plugin {:query-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)
+                              (route/plugin {:router (naive-router)})
                               {:hooks
                                {::bread/attrs-map
                                 [{:action/name ::bread/value

--- a/test/core/systems/bread/alpha/route_test.clj
+++ b/test/core/systems/bread/alpha/route_test.clj
@@ -60,10 +60,7 @@
           :dispatcher/key :page
           :dispatcher/pull [:db/id :thing/slug]
           :route/params {:lang "en"
-                         :slug "empty-dispatcher-map"}
-          :route/match {:dispatcher/component Page
-                        :route/params {:lang "en"
-                                       :slug "empty-dispatcher-map"}}}
+                         :slug "empty-dispatcher-map"}}
          "/en/empty-dispatcher-map"
 
          {:dispatcher/type :dispatcher.type/page
@@ -72,10 +69,7 @@
           :dispatcher/key :page
           :dispatcher/pull [:db/id :thing/slug]
           :post/type :post.type/page
-          :route/params {:lang nil :slug "overridden"}
-          :route/match {:dispatcher/i18n? false
-                        :route/params {:lang nil :slug "overridden"}
-                        :dispatcher/component Page}}
+          :route/params {:lang nil :slug "overridden"}}
          "/overridden"
 
          {:dispatcher/type :whatevs
@@ -84,12 +78,7 @@
           :dispatcher/key :page
           :dispatcher/pull [:db/id :thing/slug]
           :route/params {:lang "en"
-                         :slug "no-defaults"}
-          :route/match {:dispatcher/type :whatevs
-                        :dispatcher/defaults? false
-                        :dispatcher/component Page
-                        :route/params {:lang "en"
-                                       :slug "no-defaults"}}}
+                         :slug "no-defaults"}}
          "/en/no-defaults"
 
          {:dispatcher/type :whatevs
@@ -99,11 +88,7 @@
           :post/type :post.type/page
           :dispatcher/pull [:db/id :thing/slug]
           :route/params {:lang "en"
-                         :slug "not-found"}
-          :route/match {:dispatcher/type :whatevs
-                        :dispatcher/component Page
-                        :route/params {:lang "en"
-                                       :slug "not-found"}}}
+                         :slug "not-found"}}
          "/en/not-found"
 
          {:dispatcher/type :whatevs
@@ -113,10 +98,7 @@
           :dispatcher/pull nil
           :post/type :post.type/page
           :route/params {:lang "en"
-                         :slug "no-component"}
-          :route/match {:dispatcher/type :whatevs
-                        :route/params {:lang "en"
-                                       :slug "no-component"}}}
+                         :slug "no-component"}}
          "/en/no-component"
 
         ;;

--- a/test/core/systems/bread/alpha/taxon_test.clj
+++ b/test/core/systems/bread/alpha/taxon_test.clj
@@ -5,9 +5,11 @@
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.i18n :as i18n]
     [systems.bread.alpha.database :as db]
+    [systems.bread.alpha.route :as route]
     [systems.bread.alpha.taxon :as taxon]
     [systems.bread.alpha.dispatcher :as dispatcher]
     [systems.bread.alpha.test-helpers :refer [db->plugin
+                                              naive-router
                                               plugins->loaded]]))
 
 (deftest test-dispatch-taxon-expansions
@@ -17,6 +19,7 @@
                               (i18n/plugin {:query-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)
+                              (route/plugin {:router (naive-router)})
                               {:hooks
                                {::bread/attrs-map
                                 [{:action/name ::bread/value

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -82,7 +82,7 @@
     (bread/dispatcher* [_ _])
     (bread/params [this match]
       (naive-params (:uri match)))
-    (bread/params* [this req]
+    (bread/route-params [this req]
       (naive-params (:uri req)))))
 
 (defn map->router [routes]

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -67,6 +67,13 @@
                                (string/split (or uri "") #"/"))]
     {:field/lang lang :thing/slugs* slugs}))
 
+(defmethod bread/action ::naive-params
+  [{:keys [uri]} _ _]
+  (naive-params uri))
+
+(defn naive-plugin []
+  {:hooks {::route/params [{:action/name ::naive-params}]}})
+
 (defn naive-router []
   (reify bread/Router
     (bread/match [this req]

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -111,7 +111,8 @@
       (:route/spec match))
     (bread/params [_ match]
       (:route/params match))
-    (bread/route-params [_ _])
+    (bread/route-params [_ req]
+      (:route/params (get routes (:uri req))))
     (bread/dispatcher [_ match]
       match)
     (bread/route-dispatcher [_ req]

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -76,7 +76,6 @@
 
 (defn naive-router []
   (reify bread/Router
-    (bread/dispatcher [_ _])
     (bread/route-dispatcher [_ _])
     (bread/route-params [this req]
       (naive-params (:uri req)))))
@@ -105,8 +104,6 @@
       (:route/spec (get routes (:uri req))))
     (bread/route-params [_ req]
       (:route/params (get routes (:uri req))))
-    (bread/dispatcher [_ match]
-      match)
     (bread/route-dispatcher [_ req]
       (get routes (:uri req)))
     (bread/routes [_]

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -1,5 +1,6 @@
 (ns systems.bread.alpha.test-helpers
   (:require
+    [clojure.string :as string]
     [clojure.tools.logging :as log]
     [clojure.test :as t]
     [systems.bread.alpha.core :as bread]
@@ -60,6 +61,22 @@
 
 (comment
   (macroexpand '(use-db :each {:my :config})))
+
+(defn- naive-params [uri]
+  (let [[lang & slugs] (filter (complement empty?)
+                               (string/split (or uri "") #"/"))]
+    {:field/lang lang :thing/slugs* slugs}))
+
+(defn naive-router []
+  (reify bread/Router
+    (bread/match [this req]
+      {:uri (:uri req)})
+    (bread/dispatcher [_ _])
+    (bread/dispatcher* [_ _])
+    (bread/params [this match]
+      (naive-params (:uri match)))
+    (bread/params* [this req]
+      (naive-params (:uri req)))))
 
 (defn map->router [routes]
   "Takes a map m like:

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -79,7 +79,7 @@
     (bread/match [this req]
       {:uri (:uri req)})
     (bread/dispatcher [_ _])
-    (bread/dispatcher* [_ _])
+    (bread/route-dispatcher [_ _])
     (bread/params [this match]
       (naive-params (:uri match)))
     (bread/route-params [this req]
@@ -113,6 +113,7 @@
       (:route/params match))
     (bread/dispatcher [_ match]
       match)
+    (bread/route-dispatcher [_ req])
     (bread/routes [_]
       routes)))
 

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -80,8 +80,6 @@
       {:uri (:uri req)})
     (bread/dispatcher [_ _])
     (bread/route-dispatcher [_ _])
-    (bread/params [this match]
-      (naive-params (:uri match)))
     (bread/route-params [this req]
       (naive-params (:uri req)))))
 
@@ -109,8 +107,6 @@
       (get routes (:uri req)))
     (bread/route-spec [_ match]
       (:route/spec match))
-    (bread/params [_ match]
-      (:route/params match))
     (bread/route-params [_ req]
       (:route/params (get routes (:uri req))))
     (bread/dispatcher [_ match]

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -62,7 +62,7 @@
 (comment
   (macroexpand '(use-db :each {:my :config})))
 
-(defn- naive-params [uri]
+(defn naive-params [uri]
   (let [[lang & slugs] (filter (complement empty?)
                                (string/split (or uri "") #"/"))]
     {:field/lang lang :thing/slugs* slugs}))

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -76,8 +76,6 @@
 
 (defn naive-router []
   (reify bread/Router
-    (bread/match [this req]
-      {:uri (:uri req)})
     (bread/dispatcher [_ _])
     (bread/route-dispatcher [_ _])
     (bread/route-params [this req]
@@ -103,8 +101,6 @@
                 (when (= route-name (:name route))
                   (reduced path)))
               nil routes))
-    (bread/match [_ req]
-      (get routes (:uri req)))
     (bread/route-spec [_ match]
       (:route/spec match))
     (bread/route-params [_ req]

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -111,9 +111,11 @@
       (:route/spec match))
     (bread/params [_ match]
       (:route/params match))
+    (bread/route-params [_ _])
     (bread/dispatcher [_ match]
       match)
-    (bread/route-dispatcher [_ req])
+    (bread/route-dispatcher [_ req]
+      (get routes (:uri req)))
     (bread/routes [_]
       routes)))
 

--- a/test/core/systems/bread/alpha/test_helpers.clj
+++ b/test/core/systems/bread/alpha/test_helpers.clj
@@ -85,11 +85,11 @@
   "Takes a map m like:
 
   {\"/first/route\"
-   {:bread/dispatcher :dispatcher.type/first
+   {:dispatcher/type ::first
     :bread/component 'first-component
     :route/params ...}
    \"/second/route\"
-   {:bread/dispatcher :dispatcher.type/second
+   {:dispatcher/type ::second
     :bread/component 'second-component
     :route/params ...}}
 
@@ -101,8 +101,8 @@
                 (when (= route-name (:name route))
                   (reduced path)))
               nil routes))
-    (bread/route-spec [_ match]
-      (:route/spec match))
+    (bread/route-spec [_ req]
+      (:route/spec (get routes (:uri req))))
     (bread/route-params [_ req]
       (:route/params (get routes (:uri req))))
     (bread/dispatcher [_ match]
@@ -116,11 +116,11 @@
   "Takes a map m like:
 
   {\"/first/route\"
-   {:bread/dispatcher :dispatcher.type/first
+   {:dispatcher/type ::first
     :bread/component 'first-component
     :route/params ...}
    \"/second/route\"
-   {:bread/dispatcher :dispatcher.type/second
+   {:dispatcher/type ::second
     :bread/component 'second-component
     :route/params ...}}
 


### PR DESCRIPTION
- [x] deprecate `bread/match`
- [x] implement `bread/route-params`
- [x] implement `bread/route-dispatcher`
- [x] refactor `bread/route-spec` to take a `req`
- [x] replace `bread/params`
- [x] replace `bread/dispatcher`
- [x] remove `bread/match`
- [x] figure out if `bread/path` still belongs in the `Router` protocol