### PR TITLE
Introduce `thing` ns, move ancestry logic

### DIFF
--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -26,9 +26,10 @@
                   ['?_ :thing/children earliest-ancestor-sym])]))))
 
 (defn- update-inputs [query-args input-syms rule-def]
-  (-> query-args
-      (update-in [0 :in] #(apply conj % (symbol "%") input-syms))
-      (conj [rule-def])))
+  (let [sym (symbol "%")]
+    (-> query-args
+        (update-in [0 :in] #(apply conj % sym input-syms))
+        (conj [rule-def]))))
 
 (defn ancestralize [query-args slugs & {e :e-sym
                                         :or {e '?e}}]

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -24,3 +24,18 @@
                                       (rest slug-syms))))
            [(list 'not-join [earliest-ancestor-sym]
                   ['?_ :thing/children earliest-ancestor-sym])]))))
+
+(defn ancestralize [query slugs]
+  (let [depth (count slugs)
+        slug-syms (take depth (syms "?slug_"))
+        ;; Place slug input args in ancestral order (earliest ancestor first),
+        ;; since that is the order in which they appear in the URL.
+        input-syms (reverse slug-syms)
+        rule-invocation (apply list 'ancestry '?e slug-syms)
+        rule (create-ancestry-rule depth)]
+    (apply conj
+           (-> query
+               (update-in [0 :in] #(apply conj % (symbol "%") input-syms))
+               (update-in [0 :where] conj rule-invocation)
+               (conj [rule]))
+           slugs)))

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -25,11 +25,20 @@
            [(list 'not-join [earliest-ancestor-sym]
                   ['?_ :thing/children earliest-ancestor-sym])]))))
 
+(defn- add-rule-def [query-args idx rule-def]
+  (if idx
+    (update query-args (inc idx) conj rule-def)
+    (conj query-args [rule-def])))
+
 (defn- update-inputs [query-args input-syms rule-def]
-  (let [sym (symbol "%")]
+  (let [sym (symbol "%")
+        in (get-in query-args [0 :in])
+        rules-idx (first (keep-indexed #(when (= sym %2) %1) in))]
     (-> query-args
-        (update-in [0 :in] #(apply conj % sym input-syms))
-        (conj [rule-def]))))
+        (update-in [0 :in] #(if rules-idx % (conj % sym)))
+        (update-in [0 :in] concat input-syms)
+        (update-in [0 :in] vec)
+        (add-rule-def rules-idx rule-def))))
 
 (defn ancestralize [query-args slugs & {e :e-sym
                                         :or {e '?e}}]

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -25,7 +25,8 @@
            [(list 'not-join [earliest-ancestor-sym]
                   ['?_ :thing/children earliest-ancestor-sym])]))))
 
-(defn ancestralize [query-args slugs]
+(defn ancestralize [query-args slugs & {e :e-sym
+                                        :or {e '?e}}]
   "Given ::db/query args vector and a list of slugs, returns an args vector
   asserting that the ancestry of things corresponding to each :thing/slug is an
   unbroken chain of :thing/children ancestors."
@@ -34,7 +35,7 @@
         ;; Place slug input args in ancestral order (earliest ancestor first),
         ;; since that is the order in which they appear in the URL.
         input-syms (reverse slug-syms)
-        rule-invocation (apply list 'ancestry '?e slug-syms)
+        rule-invocation (apply list 'ancestry e slug-syms)
         rule (create-ancestry-rule depth)]
     (apply conj
            (-> query-args

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -25,7 +25,10 @@
            [(list 'not-join [earliest-ancestor-sym]
                   ['?_ :thing/children earliest-ancestor-sym])]))))
 
-(defn ancestralize [query slugs]
+(defn ancestralize [query-args slugs]
+  "Given ::db/query args vector and a list of slugs, returns an args vector
+  asserting that the ancestry of things corresponding to each :thing/slug is an
+  unbroken chain of :thing/children ancestors."
   (let [depth (count slugs)
         slug-syms (take depth (syms "?slug_"))
         ;; Place slug input args in ancestral order (earliest ancestor first),
@@ -34,7 +37,7 @@
         rule-invocation (apply list 'ancestry '?e slug-syms)
         rule (create-ancestry-rule depth)]
     (apply conj
-           (-> query
+           (-> query-args
                (update-in [0 :in] #(apply conj % (symbol "%") input-syms))
                (update-in [0 :where] conj rule-invocation)
                (conj [rule]))

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -25,6 +25,11 @@
            [(list 'not-join [earliest-ancestor-sym]
                   ['?_ :thing/children earliest-ancestor-sym])]))))
 
+(defn- update-inputs [query-args input-syms rule-def]
+  (-> query-args
+      (update-in [0 :in] #(apply conj % (symbol "%") input-syms))
+      (conj [rule-def])))
+
 (defn ancestralize [query-args slugs & {e :e-sym
                                         :or {e '?e}}]
   "Given ::db/query args vector and a list of slugs, returns an args vector
@@ -36,10 +41,9 @@
         ;; since that is the order in which they appear in the URL.
         input-syms (reverse slug-syms)
         rule-invocation (apply list 'ancestry e slug-syms)
-        rule (create-ancestry-rule depth)]
+        rule-def (create-ancestry-rule depth)]
     (apply conj
            (-> query-args
-               (update-in [0 :in] #(apply conj % (symbol "%") input-syms))
-               (update-in [0 :where] conj rule-invocation)
-               (conj [rule]))
+               (update-inputs input-syms rule-def)
+               (update-in [0 :where] conj rule-invocation))
            slugs)))

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -1,0 +1,26 @@
+(ns systems.bread.alpha.thing
+  (:require
+    [systems.bread.alpha.core :as bread]))
+
+(defn- syms
+  ([prefix]
+   (syms prefix 0))
+  ([prefix start]
+   (for [n (range)] (symbol (str prefix (+ start n))))))
+
+(defn create-ancestry-rule [depth]
+  (let [slug-syms (take depth (syms "?slug_"))
+        descendant-syms (take depth (cons '?child (syms "?ancestor_" 1)))
+        earliest-ancestor-sym (last descendant-syms)]
+    (vec (concat
+           [(apply list 'ancestry '?child slug-syms)]
+           [['?child :thing/slug (first slug-syms)]]
+           (mapcat
+             (fn [[ancestor-sym descendant-sym slug-sym]]
+               [[ancestor-sym :thing/children descendant-sym]
+                [ancestor-sym :thing/slug slug-sym]])
+             (partition 3 (interleave (rest descendant-syms)
+                                      (butlast descendant-syms)
+                                      (rest slug-syms))))
+           [(list 'not-join [earliest-ancestor-sym]
+                  ['?_ :thing/children earliest-ancestor-sym])]))))

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -11,56 +11,6 @@
                                               naive-router
                                               plugins->loaded]]))
 
-(deftest test-create-post-ancestry-rule
-  (are
-    [rule n]
-    (= rule (post/create-post-ancestry-rule n))
-
-    '[(post-ancestry ?child ?slug_0)
-      [?child :thing/slug ?slug_0]
-      (not-join [?child] [?_ :thing/children ?child])]
-    1
-
-    '[(post-ancestry ?child ?slug_0 ?slug_1)
-      [?child :thing/slug ?slug_0]
-      [?ancestor_1 :thing/children ?child]
-      [?ancestor_1 :thing/slug ?slug_1]
-      (not-join [?ancestor_1] [?_ :thing/children ?ancestor_1])]
-    2
-
-    '[(post-ancestry ?child ?slug_0 ?slug_1 ?slug_2)
-      [?child :thing/slug ?slug_0]
-      [?ancestor_1 :thing/children ?child]
-      [?ancestor_1 :thing/slug ?slug_1]
-      [?ancestor_2 :thing/children ?ancestor_1]
-      [?ancestor_2 :thing/slug ?slug_2]
-      (not-join [?ancestor_2] [?_ :thing/children ?ancestor_2])]
-    3
-
-    '[(post-ancestry ?child ?slug_0 ?slug_1 ?slug_2 ?slug_3)
-      [?child :thing/slug ?slug_0]
-      [?ancestor_1 :thing/children ?child]
-      [?ancestor_1 :thing/slug ?slug_1]
-      [?ancestor_2 :thing/children ?ancestor_1]
-      [?ancestor_2 :thing/slug ?slug_2]
-      [?ancestor_3 :thing/children ?ancestor_2]
-      [?ancestor_3 :thing/slug ?slug_3]
-      (not-join [?ancestor_3] [?_ :thing/children ?ancestor_3])]
-    4
-
-    '[(post-ancestry ?child ?slug_0 ?slug_1 ?slug_2 ?slug_3 ?slug_4)
-      [?child :thing/slug ?slug_0]
-      [?ancestor_1 :thing/children ?child]
-      [?ancestor_1 :thing/slug ?slug_1]
-      [?ancestor_2 :thing/children ?ancestor_1]
-      [?ancestor_2 :thing/slug ?slug_2]
-      [?ancestor_3 :thing/children ?ancestor_2]
-      [?ancestor_3 :thing/slug ?slug_3]
-      [?ancestor_4 :thing/children ?ancestor_3]
-      [?ancestor_4 :thing/slug ?slug_4]
-      (not-join [?ancestor_4] [?_ :thing/children ?ancestor_4])]
-    5))
-
 (deftest test-post-dispatcher
   (let [attrs-map {:thing/fields {:db/cardinality :db.cardinality/many}
                    :post/taxons  {:db/cardinality :db.cardinality/many}}
@@ -89,11 +39,11 @@
         ['{:find [(pull ?e [:db/id
                             :thing/slug
                             {:thing/fields [*]}]) .]
-           :where [(post-ancestry ?e ?slug_0)
+           :where [(ancestry ?e ?slug_0)
                    [?e :post/type ?type]
                    [?e :post/status ?status]]
            :in [$ % ?slug_0 ?type ?status]}
-         '[[(post-ancestry ?child ?slug_0)
+         '[[(ancestry ?child ?slug_0)
             [?child :thing/slug ?slug_0]
             (not-join [?child] [?_ :thing/children ?child])]]
          "hello"
@@ -121,11 +71,11 @@
         ['{:find [(pull ?e [:db/id
                             :thing/slug
                             {:thing/fields [*]}]) .]
-           :where [(post-ancestry ?e ?slug_0)
+           :where [(ancestry ?e ?slug_0)
                    [?e :post/type ?type]
                    [?e :post/status ?status]]
            :in [$ % ?slug_0 ?type ?status]}
-         '[[(post-ancestry ?child ?slug_0)
+         '[[(ancestry ?child ?slug_0)
             [?child :thing/slug ?slug_0]
             (not-join [?child] [?_ :thing/children ?child])]]
          "hello"

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -63,8 +63,8 @@
 
 (deftest test-ancestralize
   (are
-    [expected query-args slugs]
-    (= expected (thing/ancestralize query-args slugs))
+    [expected query-args slugs args]
+    (= expected (apply thing/ancestralize query-args slugs args))
 
     ;; Querying for a top-level thing should just assert that
     ;; that thing has no parent.
@@ -81,6 +81,7 @@
        :where []}
       ::DB]
     ["a"]
+    nil
 
     ;; Existing :in and :where should be left intact.
     '[{:find [?e]
@@ -99,6 +100,7 @@
       ::DB
       :published]
     ["a"]
+    nil
 
     ;; Querying for a level-2 thing asserts a single level of ancestry.
     '[{:find [?e]
@@ -118,6 +120,7 @@
        :where []}
       ::DB]
     ["a" "b"]
+    nil
 
     ;; Level-3, etc.
     '[{:find [?e]
@@ -140,6 +143,26 @@
        :where []}
       ::DB]
     ["a" "b" "c"]
+    nil
+
+    ;; Supports specifying an entity symbol.
+    '[{:find [?EEEEE]
+       :in [$ ?status % ?slug_0]
+       :where [[?EEEEE :post/status ?status]
+               (ancestry ?EEEEE ?slug_0)]}
+      ::DB
+      :published
+      [[(ancestry ?child ?slug_0)
+        [?child :thing/slug ?slug_0]
+        (not-join [?child] [?_ :thing/children ?child])]]
+      "a"]
+    '[{:find [?EEEEE]
+       :in [$ ?status]
+       :where [[?EEEEE :post/status ?status]]}
+      ::DB
+      :published]
+    ["a"]
+    [:e-sym '?EEEEE]
 
     ;;
     ))

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -1,0 +1,66 @@
+(ns systems.bread.alpha.thing-test
+  (:require
+    [clojure.test :refer [deftest are]]
+    [systems.bread.alpha.core :as bread]
+    [systems.bread.alpha.i18n :as i18n]
+    [systems.bread.alpha.database :as db]
+    [systems.bread.alpha.thing :as thing]
+    [systems.bread.alpha.route :as route]
+    [systems.bread.alpha.dispatcher :as dispatcher]
+    [systems.bread.alpha.test-helpers :refer [db->plugin
+                                              naive-router
+                                              plugins->loaded]]))
+
+(deftest test-create-ancestry-rule
+  (are
+    [rule n]
+    (= rule (thing/create-ancestry-rule n))
+
+    '[(ancestry ?child ?slug_0)
+      [?child :thing/slug ?slug_0]
+      (not-join [?child] [?_ :thing/children ?child])]
+    1
+
+    '[(ancestry ?child ?slug_0 ?slug_1)
+      [?child :thing/slug ?slug_0]
+      [?ancestor_1 :thing/children ?child]
+      [?ancestor_1 :thing/slug ?slug_1]
+      (not-join [?ancestor_1] [?_ :thing/children ?ancestor_1])]
+    2
+
+    '[(ancestry ?child ?slug_0 ?slug_1 ?slug_2)
+      [?child :thing/slug ?slug_0]
+      [?ancestor_1 :thing/children ?child]
+      [?ancestor_1 :thing/slug ?slug_1]
+      [?ancestor_2 :thing/children ?ancestor_1]
+      [?ancestor_2 :thing/slug ?slug_2]
+      (not-join [?ancestor_2] [?_ :thing/children ?ancestor_2])]
+    3
+
+    '[(ancestry ?child ?slug_0 ?slug_1 ?slug_2 ?slug_3)
+      [?child :thing/slug ?slug_0]
+      [?ancestor_1 :thing/children ?child]
+      [?ancestor_1 :thing/slug ?slug_1]
+      [?ancestor_2 :thing/children ?ancestor_1]
+      [?ancestor_2 :thing/slug ?slug_2]
+      [?ancestor_3 :thing/children ?ancestor_2]
+      [?ancestor_3 :thing/slug ?slug_3]
+      (not-join [?ancestor_3] [?_ :thing/children ?ancestor_3])]
+    4
+
+    '[(ancestry ?child ?slug_0 ?slug_1 ?slug_2 ?slug_3 ?slug_4)
+      [?child :thing/slug ?slug_0]
+      [?ancestor_1 :thing/children ?child]
+      [?ancestor_1 :thing/slug ?slug_1]
+      [?ancestor_2 :thing/children ?ancestor_1]
+      [?ancestor_2 :thing/slug ?slug_2]
+      [?ancestor_3 :thing/children ?ancestor_2]
+      [?ancestor_3 :thing/slug ?slug_3]
+      [?ancestor_4 :thing/children ?ancestor_3]
+      [?ancestor_4 :thing/slug ?slug_4]
+      (not-join [?ancestor_4] [?_ :thing/children ?ancestor_4])]
+    5))
+
+(comment
+  (require '[kaocha.repl :as k])
+  (k/run {:color? false}))

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -164,6 +164,33 @@
     ["a"]
     [:e-sym '?EEEEE]
 
+    ;; Should find existing % input and place rules in the correct input slots.
+    '[{:find [?e]
+       :in [$ ?status % ?type ?slug_0]
+       :where [[?e :post/status ?status]
+               (my-type-rule ?type)
+               (ancestry ?e ?slug_0)]}
+      ::DB
+      :published
+      [[(my-type-rule ?type)
+        [?e :post/type ?type]]
+       [(ancestry ?child ?slug_0)
+        [?child :thing/slug ?slug_0]
+        (not-join [?child] [?_ :thing/children ?child])]]
+      :my-type
+      "a"]
+    '[{:find [?e]
+       :in [$ ?status % ?type]
+       :where [[?e :post/status ?status]
+               (my-type-rule ?type)]}
+      ::DB
+      :published
+      [[(my-type-rule ?type)
+        [?e :post/type ?type]]]
+      :my-type]
+    ["a"]
+    nil
+
     ;;
     ))
 


### PR DESCRIPTION
Also make `ancestralize` more robust:
- support arbitrary entity symbols aside from `?e`
- ensure Datalog rules and corresponding inputs are correctly maintained