### PR TITLE
::thing/by-* dispatchers

### DIFF
--- a/dev/main.edn
+++ b/dev/main.edn
@@ -58,7 +58,7 @@
    ["/{field/lang}"
     [""
      {:name :home
-      :dispatcher/type :systems.bread.alpha.post/page
+      :dispatcher/type :systems.bread.alpha.post/page=>
       :dispatcher/component #var systems.bread.alpha.cms.theme/HomePage}]
     ["/i/{db/id}"
      {:name :id
@@ -70,11 +70,11 @@
       :dispatcher/component #var systems.bread.alpha.cms.theme/Tag}]
     ["/{thing/slug*}"
      {:name :page
-      :dispatcher/type :systems.bread.alpha.post/page
+      :dispatcher/type :systems.bread.alpha.post/page=>
       :dispatcher/component #var systems.bread.alpha.cms.theme/InteriorPage}]
     ["/page/{thing/slug*}"
      {:name :page!
-      :dispatcher/type :systems.bread.alpha.post/page
+      :dispatcher/type :systems.bread.alpha.post/page=>
       :dispatcher/component #var systems.bread.alpha.cms.theme/InteriorPage}]]]
   {:conflicts nil}]
  :bread/profilers

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -60,6 +60,10 @@
      {:name :home
       :dispatcher/type :systems.bread.alpha.post/page
       :dispatcher/component #var systems.bread.alpha.cms.theme/HomePage}]
+    ["/i/{db/id}"
+     {:name :id
+      :dispatcher/type :systems.bread.alpha.thing/by-id=>
+      :dispatcher/component #var systems.bread.alpha.cms.theme/InteriorPage}]
     ["/tag/{thing/slug}"
      {:name :tag
       :dispatcher/type :systems.bread.alpha.post/tag

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -19,14 +19,14 @@
                  (map second result))]
     (assoc post :post/fields fields)))
 
-(defmethod bread/dispatch ::post=>
-  post=>
+(defn by-slug*-expansion
   [{{post-type :post/type
      post-status :post/status
      :or {post-status :post.status/published}
      :as dispatcher} ::bread/dispatcher
     :as req}]
-  "Dispatcher for a single post. Optionally specify:
+  "Returns an expansion for querying a single post by :thing/slug*. Observes
+  the options in ::bread/dispatcher, which may specify:
   - :post/type (default nil, meaning all types)
   - :post/status (default :post.status/published)"
   (let [params (:route/params dispatcher)
@@ -39,41 +39,31 @@
                  (thing/ancestralize (string/split (:thing/slug* params "") #"/"))
                  (where (filter seq [where-post-type
                                      ['?status :post/status post-status]])))
-        query-key (or (:dispatcher/key dispatcher) :post)
-        post-expansion {:expansion/name ::db/query
-                        :expansion/key query-key
-                        :expansion/db (db/database req)
-                        :expansion/args args
-                        :expansion/description
-                        "Query for posts matching the current request URI"}]
-    {:expansions (bread/hook req ::i18n/expansions post-expansion)}))
+        query-key (or (:dispatcher/key dispatcher) :post)]
+    {:expansion/name ::db/query
+     :expansion/key query-key
+     :expansion/db (db/database req)
+     :expansion/args args
+     :expansion/description
+     "Query for a single post matching the current request URI"}))
+
+(defmethod bread/dispatch ::post=>
+  post=>
+  [req]
+  "Dispatcher for a single post. Optionally specify:
+  - :post/type (default nil, meaning all types)
+  - :post/status (default :post.status/published)"
+  {:expansions (bread/hook req ::i18n/expansions (by-slug*-expansion req))})
 
 (defmethod bread/dispatch ::page=>
   page=>
-  [{{pull :dispatcher/pull
-     post-type :post/type
-     post-status :post/status
-     :or {post-type :post.type/page
-          post-status :post.status/published}
-     :as dispatcher} ::bread/dispatcher
-    :as req}]
+  [req]
   "Dispatcher for a single page Optionally specify:
-  - :post/type (default nil, meaning all types)
   - :post/status (default :post.status/published)"
-  (let [params (:route/params dispatcher)
-        ;; Ensure we always have :db/id
-        page-args
-        (-> [{:find [(list 'pull '?e (ensure-db-id pull)) '.]
-              :in '[$]
-              :where []}]
-            (thing/ancestralize (string/split (:thing/slug* params "") #"/"))
-            (where [['?type :post/type post-type]
-                    ['?status :post/status post-status]]))
-        query-key (or (:dispatcher/key dispatcher) :post)
-        page-expansion {:expansion/name ::db/query
-                        :expansion/key query-key
-                        :expansion/db (db/database req)
-                        :expansion/args page-args
-                        :expansion/description
-                        "Query for pages matching the current request URI"}]
+  (let [page-expansion
+        (-> req
+            (assoc-in [::bread/dispatcher :post/type] :post.type/page)
+            by-slug*-expansion
+            (assoc :expansion/description
+                   "Query for a single page matching the current request URI"))]
     {:expansions (bread/hook req ::i18n/expansions page-expansion)}))

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -39,13 +39,15 @@
            :expansion/description
            "Query for a single post matching the current request URI")))
 
-(defmethod bread/dispatch ::post=>
+(defmethod bread/dispatch ::by-slug*=>
   post=>
   [req]
   "Dispatcher for a single post. Optionally specify:
   - :post/type (default nil, meaning all types)
   - :post/status (default :post.status/published)"
   {:expansions (bread/hook req ::i18n/expansions (by-slug*-expansion req))})
+
+(derive ::post=> ::by-slug*=>)
 
 (defmethod bread/dispatch ::page=>
   page=>

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -19,7 +19,7 @@
                  (map second result))]
     (assoc post :post/fields fields)))
 
-(defmethod bread/dispatch ::page
+(defmethod bread/dispatch ::page=>
   [{{pull :dispatcher/pull
      post-type :post/type
      post-status :post/status

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -15,8 +15,7 @@
         fields (reduce
                  (fn [fields {:field/keys [key content]}]
                    (assoc fields key (edn/read-string content)))
-                 {}
-                 (map second result))]
+                 {} (map second result))]
     (assoc post :post/fields fields)))
 
 (defn by-slug*-expansion

--- a/src/systems/bread/alpha/post.cljc
+++ b/src/systems/bread/alpha/post.cljc
@@ -20,15 +20,15 @@
     (assoc post :post/fields fields)))
 
 (defmethod bread/dispatch ::post=>
-  dispatch-post
-  "Dispatcher for a single post. Optionally specify:
-  - :post/type (default nil, meaning all types)
-  - :post/status (default :post.status/published)"
+  post=>
   [{{post-type :post/type
      post-status :post/status
      :or {post-status :post.status/published}
      :as dispatcher} ::bread/dispatcher
     :as req}]
+  "Dispatcher for a single post. Optionally specify:
+  - :post/type (default nil, meaning all types)
+  - :post/status (default :post.status/published)"
   (let [params (:route/params dispatcher)
         ;; Ensure we always have :db/id
         pull (ensure-db-id (:dispatcher/pull dispatcher))
@@ -40,15 +40,16 @@
                  (where (filter seq [where-post-type
                                      ['?status :post/status post-status]])))
         query-key (or (:dispatcher/key dispatcher) :post)
-        page-expansion {:expansion/name ::db/query
+        post-expansion {:expansion/name ::db/query
                         :expansion/key query-key
                         :expansion/db (db/database req)
                         :expansion/args args
                         :expansion/description
                         "Query for posts matching the current request URI"}]
-    {:expansions (bread/hook req ::i18n/expansions page-expansion)}))
+    {:expansions (bread/hook req ::i18n/expansions post-expansion)}))
 
 (defmethod bread/dispatch ::page=>
+  page=>
   [{{pull :dispatcher/pull
      post-type :post/type
      post-status :post/status
@@ -56,6 +57,9 @@
           post-status :post.status/published}
      :as dispatcher} ::bread/dispatcher
     :as req}]
+  "Dispatcher for a single page Optionally specify:
+  - :post/type (default nil, meaning all types)
+  - :post/status (default :post.status/published)"
   (let [params (:route/params dispatcher)
         ;; Ensure we always have :db/id
         page-args

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -132,3 +132,9 @@
       {:expansions [{:expansion/name ::bread/value
                      :expansion/key (:dispatcher/key dispatcher)
                      :expansion/value false}]})))
+
+(defmethod bread/dispatch ::thing=>
+  by-slug*=>
+  [req]
+  "Dispatch req by the :thing/slug* in the URI."
+  {:expansions (bread/hook req ::i18n/expansions (by-slug*-expansion req))})

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -2,7 +2,8 @@
   (:require
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.database :as db]
-    [systems.bread.alpha.i18n :as i18n])
+    [systems.bread.alpha.i18n :as i18n]
+    [systems.bread.alpha.util.datalog :as datalog])
   (:import
     [java.util UUID]))
 
@@ -72,7 +73,8 @@
   "Dispatch req by the UUID in :route/params"
   (let [k (:params-key dispatcher :thing/uuid)]
     (if-let [uuid (->uuid (get (:route/params dispatcher) k))]
-      (let [query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
+      (let [pull (datalog/ensure-db-id (:dispatcher/pull dispatcher))
+            query {:find [(list 'pull '?e pull) '.]
                    :in '[$ ?uuid]
                    :where '[[?e :thing/uuid ?uuid]]}
             expansion {:expansion/key (:dispatcher/key dispatcher)
@@ -94,7 +96,8 @@
   "Dispatch req by the db/id in :route/params"
   (let [k (:params-key dispatcher :db/id)]
     (if-let [id (->int (get (:route/params dispatcher) k))]
-      (let [query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
+      (let [pull (datalog/ensure-db-id (:dispatcher/pull dispatcher))
+            query {:find [(list 'pull '?e pull) '.]
                    :in '[$ ?e]}
             expansion {:expansion/key (:dispatcher/key dispatcher)
                        :expansion/name ::db/query

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -77,3 +77,17 @@
                    :expansion/db (db/database req)
                    :expansion/args [query uuid]}]
     {:expansions (bread/hook req ::i18n/expansions expansion)}))
+
+(defmethod bread/dispatch ::by-id=>
+  by-id=>
+  [{:as req ::bread/keys [dispatcher]}]
+  "Dispatch req by the db/id in :route/params"
+  (let [k (:params-key dispatcher :db/id)
+        id (Integer. (get (:route/params dispatcher) k))
+        query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
+               :in '[$ ?e]}
+        expansion {:expansion/key (:dispatcher/key dispatcher)
+                   :expansion/name ::db/query
+                   :expansion/db (db/database req)
+                   :expansion/args [query id]}]
+    {:expansions (bread/hook req ::i18n/expansions expansion)}))

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -78,21 +78,22 @@
                    :expansion/args [query uuid]}]
     {:expansions (bread/hook req ::i18n/expansions expansion)}))
 
+(defn- ->int [x]
+  (try (Integer. x) (catch java.lang.NumberFormatException _ nil)))
+
 (defmethod bread/dispatch ::by-id=>
   by-id=>
   [{:as req ::bread/keys [dispatcher]}]
   "Dispatch req by the db/id in :route/params"
-  (try
-    (let [k (:params-key dispatcher :db/id)
-          id (Integer. (get (:route/params dispatcher) k))
-          query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
-                 :in '[$ ?e]}
-          expansion {:expansion/key (:dispatcher/key dispatcher)
-                     :expansion/name ::db/query
-                     :expansion/db (db/database req)
-                     :expansion/args [query id]}]
-      {:expansions (bread/hook req ::i18n/expansions expansion)})
-    (catch java.lang.NumberFormatException e
+  (let [k (:params-key dispatcher :db/id)]
+    (if-let [id (->int (get (:route/params dispatcher) k))]
+      (let [query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
+                   :in '[$ ?e]}
+            expansion {:expansion/key (:dispatcher/key dispatcher)
+                       :expansion/name ::db/query
+                       :expansion/db (db/database req)
+                       :expansion/args [query id]}]
+        {:expansions (bread/hook req ::i18n/expansions expansion)})
       {:expansions [{:expansion/name ::bread/value
                      :expansion/key (:dispatcher/key dispatcher)
                      :expansion/value false}]})))

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -77,6 +77,7 @@
                    :where '[[?e :thing/uuid ?uuid]]}
             expansion {:expansion/key (:dispatcher/key dispatcher)
                        :expansion/name ::db/query
+                       :expansion/description "Query by :thing/uuid."
                        :expansion/db (db/database req)
                        :expansion/args [query uuid]}]
         {:expansions (bread/hook req ::i18n/expansions expansion)})
@@ -97,6 +98,7 @@
                    :in '[$ ?e]}
             expansion {:expansion/key (:dispatcher/key dispatcher)
                        :expansion/name ::db/query
+                       :expansion/description "Query by :db/id."
                        :expansion/db (db/database req)
                        :expansion/args [query id]}]
         {:expansions (bread/hook req ::i18n/expansions expansion)})

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -133,8 +133,10 @@
                      :expansion/key (:dispatcher/key dispatcher)
                      :expansion/value false}]})))
 
-(defmethod bread/dispatch ::thing=>
+(defmethod bread/dispatch ::by-slug*=>
   by-slug*=>
   [req]
   "Dispatch req by the :thing/slug* in the URI."
   {:expansions (bread/hook req ::i18n/expansions (by-slug*-expansion req))})
+
+(derive ::thing=> ::by-slug*=>)

--- a/src/systems/bread/alpha/thing.cljc
+++ b/src/systems/bread/alpha/thing.cljc
@@ -82,12 +82,17 @@
   by-id=>
   [{:as req ::bread/keys [dispatcher]}]
   "Dispatch req by the db/id in :route/params"
-  (let [k (:params-key dispatcher :db/id)
-        id (Integer. (get (:route/params dispatcher) k))
-        query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
-               :in '[$ ?e]}
-        expansion {:expansion/key (:dispatcher/key dispatcher)
-                   :expansion/name ::db/query
-                   :expansion/db (db/database req)
-                   :expansion/args [query id]}]
-    {:expansions (bread/hook req ::i18n/expansions expansion)}))
+  (try
+    (let [k (:params-key dispatcher :db/id)
+          id (Integer. (get (:route/params dispatcher) k))
+          query {:find [(list 'pull '?e (:dispatcher/pull dispatcher)) '.]
+                 :in '[$ ?e]}
+          expansion {:expansion/key (:dispatcher/key dispatcher)
+                     :expansion/name ::db/query
+                     :expansion/db (db/database req)
+                     :expansion/args [query id]}]
+      {:expansions (bread/hook req ::i18n/expansions expansion)})
+    (catch java.lang.NumberFormatException e
+      {:expansions [{:expansion/name ::bread/value
+                     :expansion/key (:dispatcher/key dispatcher)
+                     :expansion/value false}]})))

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -97,31 +97,31 @@
 
 (use-db :each config)
 
-(defc layout [{:keys [content]}]
+(defc Layout [{:keys [content]}]
   {}
   [:body
    content])
 
-(defc home [{:keys [post]}]
+(defc Home [{:keys [post]}]
   {:query '[{:thing/fields [*]}]
    :key :post
-   :extends layout}
+   :extends Layout}
   (let [{:keys [title simple]} (:thing/fields post)]
     [:main
      [:h1 title]
      [:p (:hello simple)]]))
 
-(defc page [{:keys [post]}]
+(defc Page [{:keys [post]}]
   {:query '[{:thing/fields [*]}]
    :key :post
-   :extends layout}
+   :extends Layout}
   (let [{:keys [title simple]} (:thing/fields post)]
     [:main.interior-page
      [:h1 title]
      [:p (:hello simple)]]))
 
-(defc not-found [{:keys [i18n]}]
-  {:extends layout}
+(defc NotFound [{:keys [i18n]}]
+  {:extends Layout}
   [:main (:not-found i18n)])
 
 (deftest test-app-lifecycle
@@ -130,55 +130,55 @@
     (let [routes {"/en"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component home}
-                   :bread/component home
+                                      :dispatcher/component Home}
+                   :bread/component Home
                    :route/params {:field/lang "en"}}
                   "/fr"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component home}
-                   :bread/component home
+                                      :dispatcher/component Home}
+                   :bread/component Home
                    :route/params {:field/lang "fr"}}
                   "/en/parent-page"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component page}
-                   :bread/component page
+                                      :dispatcher/component Page}
+                   :bread/component Page
                    :route/params {:field/lang "en"
                                   :thing/slug* "parent-page"}}
                   "/en/parent-page/child-page"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component page}
-                   :bread/component page
+                                      :dispatcher/component Page}
+                   :bread/component Page
                    :route/params {:field/lang "en"
                                   :thing/slug* "parent-page/child-page"}}
                   "/fr/parent-page"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component page}
-                   :bread/component page
+                                      :dispatcher/component Page}
+                   :bread/component Page
                    :route/params {:field/lang "fr"
                                   :thing/slug* "parent-page"}}
                   "/fr/parent-page/child-page"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component page}
-                   :bread/component page
+                                      :dispatcher/component Page}
+                   :bread/component Page
                    :route/params {:field/lang "fr"
                                   :thing/slug* "parent-page/child-page"}}
                   "/en/404"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component page}
-                   :bread/component page
+                                      :dispatcher/component Page}
+                   :bread/component Page
                    :route/params {:field/lang "en"
                                   :thing/slug* "not-found"}}
                   "/fr/404"
                   {:bread/dispatcher {:dispatcher/type ::post/page
                                       :dispatcher/key :post
-                                      :dispatcher/component page}
-                   :bread/component page
+                                      :dispatcher/component Page}
+                   :bread/component Page
                    :route/params {:field/lang "fr"
                                   :thing/slug* "not-found"}}}
           router (reify bread/Router
@@ -188,7 +188,7 @@
                      (:bread/dispatcher (get routes (:uri req)))))
           plugins (defaults/plugins
                     {:db config
-                     :components {:not-found not-found}
+                     :components {:not-found NotFound}
                      :routes {:router router}
                      :i18n {:supported-langs #{:en :fr}}
                      :renderer false})

--- a/test/cms/systems/bread/alpha/app_test.clj
+++ b/test/cms/systems/bread/alpha/app_test.clj
@@ -128,54 +128,54 @@
 
   (testing "it renders a localized Ring response"
     (let [routes {"/en"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Home}
                    :bread/component Home
                    :route/params {:field/lang "en"}}
                   "/fr"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Home}
                    :bread/component Home
                    :route/params {:field/lang "fr"}}
                   "/en/parent-page"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Page}
                    :bread/component Page
                    :route/params {:field/lang "en"
                                   :thing/slug* "parent-page"}}
                   "/en/parent-page/child-page"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Page}
                    :bread/component Page
                    :route/params {:field/lang "en"
                                   :thing/slug* "parent-page/child-page"}}
                   "/fr/parent-page"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Page}
                    :bread/component Page
                    :route/params {:field/lang "fr"
                                   :thing/slug* "parent-page"}}
                   "/fr/parent-page/child-page"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Page}
                    :bread/component Page
                    :route/params {:field/lang "fr"
                                   :thing/slug* "parent-page/child-page"}}
                   "/en/404"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Page}
                    :bread/component Page
                    :route/params {:field/lang "en"
                                   :thing/slug* "not-found"}}
                   "/fr/404"
-                  {:bread/dispatcher {:dispatcher/type ::post/page
+                  {:bread/dispatcher {:dispatcher/type ::post/page=>
                                       :dispatcher/key :post
                                       :dispatcher/component Page}
                    :bread/component Page

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -85,6 +85,35 @@
         :format? true
         :compact? true
         :recur-attrs #{}}]
+      {:dispatcher/type ::post/by-slug*=>
+       :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
+       :dispatcher/key :post
+       :route/params {:lang "en" :thing/slug* "hello"}}
+
+      [{:expansion/name ::db/query
+        :expansion/description "Query for a single post matching the current request URI"
+        :expansion/key :post
+        :expansion/db ::FAKEDB
+        :expansion/args
+        ['{:find [(pull ?e [:db/id
+                            :thing/slug
+                            {:thing/fields [*]}]) .]
+           :where [(ancestry ?e ?slug_0)
+                   [?e :post/status ?status]]
+           :in [$ % ?slug_0 ?status]}
+         '[[(ancestry ?child ?slug_0)
+            [?child :thing/slug ?slug_0]
+            (not-join [?child] [?_ :thing/children ?child])]]
+         "hello"
+         :post.status/published]}
+       {:expansion/name ::i18n/fields
+        :expansion/key :post
+        :expansion/description "Process translatable fields."
+        :spaths [[:thing/fields]]
+        :field/lang :en
+        :format? true
+        :compact? true
+        :recur-attrs #{}}]
       {:dispatcher/type ::post/post=>
        :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
        :dispatcher/key :post

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -57,7 +57,7 @@
         :format? true
         :compact? true
         :recur-attrs #{}}]
-      {:dispatcher/type ::post/page
+      {:dispatcher/type ::post/page=>
        :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
        :dispatcher/key :post
        :route/params {:lang "en" :thing/slug* "hello"}}
@@ -89,7 +89,7 @@
         :format? true
         :compact? true
         :recur-attrs #{}}]
-      {:dispatcher/type ::post/page
+      {:dispatcher/type ::post/page=>
        :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
        :dispatcher/key :post
        :route/params {:lang "en" :thing/slug* "hello"}

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -93,7 +93,7 @@
 
       ;; Post type, status are dynamic.
       [{:expansion/name ::db/query
-        :expansion/description "Query for pages matching the current request URI"
+        :expansion/description "Query for posts matching the current request URI"
         :expansion/key :post
         :expansion/db ::FAKEDB
         :expansion/args
@@ -118,7 +118,7 @@
         :format? true
         :compact? true
         :recur-attrs #{}}]
-      {:dispatcher/type ::post/page=>
+      {:dispatcher/type ::post/post=>
        :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
        :dispatcher/key :post
        :route/params {:lang "en" :thing/slug* "hello"}

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -32,6 +32,35 @@
                        ::bread/expansions)))
 
       [{:expansion/name ::db/query
+        :expansion/description "Query for posts matching the current request URI"
+        :expansion/key :post
+        :expansion/db ::FAKEDB
+        :expansion/args
+        ['{:find [(pull ?e [:db/id
+                            :thing/slug
+                            {:thing/fields [*]}]) .]
+           :where [(ancestry ?e ?slug_0)
+                   [?e :post/status ?status]]
+           :in [$ % ?slug_0 ?status]}
+         '[[(ancestry ?child ?slug_0)
+            [?child :thing/slug ?slug_0]
+            (not-join [?child] [?_ :thing/children ?child])]]
+         "hello"
+         :post.status/published]}
+       {:expansion/name ::i18n/fields
+        :expansion/key :post
+        :expansion/description "Process translatable fields."
+        :spaths [[:thing/fields]]
+        :field/lang :en
+        :format? true
+        :compact? true
+        :recur-attrs #{}}]
+      {:dispatcher/type ::post/post=>
+       :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
+       :dispatcher/key :post
+       :route/params {:lang "en" :thing/slug* "hello"}}
+
+      [{:expansion/name ::db/query
         :expansion/description "Query for pages matching the current request URI"
         :expansion/key :post
         :expansion/db ::FAKEDB

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -253,7 +253,8 @@
        :expansion/description "Query by :thing/uuid."
        :expansion/key :k
        :expansion/db ::FAKEDB
-       :expansion/args ['{:find [(pull ?e [{:thing/fields [:db/id
+       :expansion/args ['{:find [(pull ?e [:db/id
+                                           {:thing/fields [:db/id
                                                            :field/key
                                                            :field/lang
                                                            :field/content]}]) .]
@@ -331,7 +332,8 @@
        :expansion/description "Query by :db/id."
        :expansion/key :k
        :expansion/db ::FAKEDB
-       :expansion/args ['{:find [(pull ?e [{:thing/fields [:db/id
+       :expansion/args ['{:find [(pull ?e [:db/id
+                                           {:thing/fields [:db/id
                                                            :field/key
                                                            :field/lang
                                                            :field/content]}]) .]

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -206,6 +206,7 @@
 
     {:expansions
      [{:expansion/name ::db/query
+       :expansion/description "Query by :thing/uuid."
        :expansion/key :k
        :expansion/db ::FAKEDB
        :expansion/args ['{:find [(pull ?e [*]) .]
@@ -232,6 +233,7 @@
     ;; Get UUID from custom :params-key if specified.
     {:expansions
      [{:expansion/name ::db/query
+       :expansion/description "Query by :thing/uuid."
        :expansion/key :k
        :expansion/db ::FAKEDB
        :expansion/args ['{:find [(pull ?e [*]) .]
@@ -248,6 +250,7 @@
     ;; Test that queries get properly internationalized.
     {:expansions
      [{:expansion/name ::db/query
+       :expansion/description "Query by :thing/uuid."
        :expansion/key :k
        :expansion/db ::FAKEDB
        :expansion/args ['{:find [(pull ?e [{:thing/fields [:db/id
@@ -287,6 +290,7 @@
 
     {:expansions
      [{:expansion/name ::db/query
+       :expansion/description "Query by :db/id."
        :expansion/key :k
        :expansion/db ::FAKEDB
        :expansion/args ['{:find [(pull ?e [*]) .] :in [$ ?e]} 123]}]}
@@ -310,6 +314,7 @@
     ;; Get id from custom :params-key if specified.
     {:expansions
      [{:expansion/name ::db/query
+       :expansion/description "Query by :db/id."
        :expansion/key :k
        :expansion/db ::FAKEDB
        :expansion/args ['{:find [(pull ?e [*]) .] :in [$ ?e]} 123]}]}
@@ -323,6 +328,7 @@
     ;; Test that queries get properly internationalized.
     {:expansions
      [{:expansion/name ::db/query
+       :expansion/description "Query by :db/id."
        :expansion/key :k
        :expansion/db ::FAKEDB
        :expansion/args ['{:find [(pull ?e [{:thing/fields [:db/id

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -285,6 +285,17 @@
      :dispatcher/pull '[*]
      :route/params {:db/id "123"}}
 
+    ;; Test with an invalid id; should 404;
+    {:expansions
+     [{:expansion/name ::bread/value
+       :expansion/key :k
+       :expansion/value false}]}
+    {:dispatcher/type ::thing/by-id=>
+     :dispatcher/key :k
+     :dispatcher/component 'Component
+     :dispatcher/pull '[*]
+     :route/params {:db/id "invalid int"}}
+
     ;; Get id from custom :params-key if specified.
     {:expansions
      [{:expansion/name ::db/query

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -218,6 +218,17 @@
      :dispatcher/pull '[*]
      :route/params {:thing/uuid "313be3ec-f849-42e7-b4b6-4493807bdc3c"}}
 
+    ;; Test with an invalid UUID; should 404;
+    {:expansions
+     [{:expansion/name ::bread/value
+       :expansion/key :k
+       :expansion/value false}]}
+    {:dispatcher/type ::thing/by-uuid=>
+     :dispatcher/key :k
+     :dispatcher/component 'Component
+     :dispatcher/pull '[*]
+     :route/params {:db/id "invalid UUID"}}
+
     ;; Get UUID from custom :params-key if specified.
     {:expansions
      [{:expansion/name ::db/query

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -193,6 +193,35 @@
     ;;
     ))
 
+(deftest test-by-slug*-expansion
+  (let [app (plugins->loaded [(db->plugin ::FAKEDB)])]
+
+    (are
+      [expansion dispatcher]
+      (= expansion
+         (thing/by-slug*-expansion (assoc app ::bread/dispatcher dispatcher)))
+
+      {:expansion/name ::db/query
+       :expansion/description "Query for a single thing matching the current request URI"
+       :expansion/key :thing
+       :expansion/db ::FAKEDB
+       :expansion/args
+       ['{:find [(pull ?e [:db/id
+                           :thing/slug
+                           {:thing/fields [*]}]) .]
+          :where [(ancestry ?e ?slug_0)]
+          :in [$ % ?slug_0]}
+        '[[(ancestry ?child ?slug_0)
+           [?child :thing/slug ?slug_0]
+           (not-join [?child] [?_ :thing/children ?child])]]
+        "hello"]}
+      {:dispatcher/type ::thing/thing=>
+       :dispatcher/pull '[:thing/slug {:thing/fields [*]}]
+       :dispatcher/key :thing
+       :route/params {:lang "en" :thing/slug* "hello"}}
+
+      )))
+
 (deftest test-by-uuid-dispatcher
   (are
     [expected dispatcher]

--- a/test/core/systems/bread/alpha/thing_test.clj
+++ b/test/core/systems/bread/alpha/thing_test.clj
@@ -277,6 +277,38 @@
        :format? true
        :recur-attrs #{}
        :spaths [[:thing/fields]]}]}
+    {:dispatcher/type ::thing/by-slug*=>
+     :dispatcher/pull '[:thing/slug {:thing/fields [:field/content]}]
+     :dispatcher/key :thing
+     :route/params {:lang "en" :thing/slug* "hello"}}
+
+    ;; ::thing/thing=> is an alias of ::thing/by-slug*=>
+    {:expansions
+     [{:expansion/name ::db/query
+       :expansion/description "Query for a single thing matching the current request URI"
+       :expansion/key :thing
+       :expansion/db ::FAKEDB
+       :expansion/args
+       ['{:find [(pull ?e [:db/id
+                           :thing/slug
+                           {:thing/fields [:db/id
+                                           :field/key
+                                           :field/lang
+                                           :field/content]}]) .]
+          :where [(ancestry ?e ?slug_0)]
+          :in [$ % ?slug_0]}
+        '[[(ancestry ?child ?slug_0)
+           [?child :thing/slug ?slug_0]
+           (not-join [?child] [?_ :thing/children ?child])]]
+        "hello"]}
+      {:expansion/name ::i18n/fields
+       :expansion/description "Process translatable fields."
+       :expansion/key :thing
+       :field/lang :en
+       :compact? true
+       :format? true
+       :recur-attrs #{}
+       :spaths [[:thing/fields]]}]}
     {:dispatcher/type ::thing/thing=>
      :dispatcher/pull '[:thing/slug {:thing/fields [:field/content]}]
      :dispatcher/key :thing


### PR DESCRIPTION
Introduce `::thing/by-id=>` and `::thing/by-uuid=>` dispatchers, as well as the trailing `=>` convention for dispatcher symbols. Convert the existing `::post/page` to this convention.