### PR TITLE
Bugfix/auth

### DIFF
--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -206,7 +206,7 @@
      ["/{field/lang}"
       [""
        {:name :home
-        :dispatcher/type ::page=>
+        :dispatcher/type ::post/page=>
         :dispatcher/component #'theme/HomePage}]
       ["/i/{db/id}"
        {:name :id

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -197,7 +197,7 @@
     [["/~"
       ["/login"
        {:name :login
-        :dispatcher/type ::auth/login
+        :dispatcher/type ::auth/login=>
         :dispatcher/component #'auth/LoginPage}]]
      ["/assets/*"
       (reitit.ring/create-resource-handler

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -194,10 +194,11 @@
 
 (defmethod ig/init-key :bread/router [_ router]
   (reitit/router
-    [["/login"
-      {:name :login
-       :dispatcher/type :systems.bread.alpha.plugin.auth/login
-       :dispatcher/component #'auth/LoginPage}]
+    [["/~"
+      ["/login"
+       {:name :login
+        :dispatcher/type ::auth/login
+        :dispatcher/component #'auth/LoginPage}]]
      ["/assets/*"
       (reitit.ring/create-resource-handler
         {:parameter :filename

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -14,6 +14,7 @@
   :app #ig/ref :bread/app}
  :bread/app
  {:db #ig/ref :bread/db
+  :auth {:login-uri "/~/login"}
   :i18n {:supported-langs #{:en :fr}}
   :routes {:router #ig/ref :bread/router}
   :components {:not-found #var systems.bread.alpha.cms.theme/NotFoundPage}

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -15,7 +15,8 @@
  :bread/app
  {:db #ig/ref :bread/db
   :auth {:login-uri "/~/login"}
-  :i18n {:supported-langs #{:en :fr}}
+  :i18n {:query-global-strings? false
+         :supported-langs #{:en :fr :es}}
   :routes {:router #ig/ref :bread/router}
   :components {:not-found #var systems.bread.alpha.cms.theme/NotFoundPage}
   :navigation {:menus {:main-nav

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -16,7 +16,8 @@
  {:db #ig/ref :bread/db
   :auth {:login-uri "/~/login"}
   :i18n {:query-global-strings? false
-         :supported-langs #{:en :fr :es}}
+         :supported-langs #{:en :fr :es :ar}
+         :fallback-lang :ar}
   :routes {:router #ig/ref :bread/router}
   :components {:not-found #var systems.bread.alpha.cms.theme/NotFoundPage}
   :navigation {:menus {:main-nav

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -14,7 +14,6 @@
   :app #ig/ref :bread/app}
  :bread/app
  {:db #ig/ref :bread/db
-  :auth {:lock-seconds 3600}
   :i18n {:supported-langs #{:en :fr}}
   :routes {:router #ig/ref :bread/router}
   :components {:not-found #var systems.bread.alpha.cms.theme/NotFoundPage}

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -37,7 +37,7 @@
              :user/email "coby@bread.systems"
              :user/password #buddy/derive ["hello" :bcrypt+blake2b-512]
              ;#_#_ ;; Uncomment to enable 2FA
-             :user/two-factor-key "AWWMEFM4ADBSQRET"
+             :user/totp-key "AWWMEFM4ADBSQRET"
              :user/failed-login-count 0
              :user/preferences "{:lang :en}"
              :user/roles

--- a/plugins/auth/auth.i18n.edn
+++ b/plugins/auth/auth.i18n.edn
@@ -1,0 +1,37 @@
+{:ar
+ #:auth{
+        :account-locked "تم قفل الحساب"
+        :enter-totp "يرجى إدخال الرمز المكون لمرة واحدة من تطبيق المصادقة."
+        :enter-username-password "يرجى إدخال اسم المستخدم وكلمة المرور."
+        :invalid-totp "رمز غير صالح. يرجى المحاولة مرة أخرى."
+        :invalid-username-password "اسم المستخدم أو كلمة المرور غير صحيحة."
+        :login "تسجيل الدخول"
+        :logout "تسجيل الخروج"
+        :login-to-bread "تسجيل الدخول إلى Bread"
+        :password "كلمة المرور"
+        :too-many-attempts "لقد قمت بعدد كبير جدًا من محاولات تسجيل الدخول. يرجى المحاولة لاحقًا."
+        :username "اسم المستخدم"
+        :verify "تحقق"
+        :welcome "مرحبًا"
+        }
+ :en
+ #:auth{
+        :account-locked "Account locked"
+        :enter-totp "Please enter the one-time code from your authenticator app."
+        :enter-username-password "Please enter your username and password."
+        :invalid-totp "Invalid code. Please try again."
+        :invalid-username-password "Invalid username or password."
+        :login "Login"
+        :logout "Logout"
+        :login-to-bread "Login to Bread"
+        :password "Password"
+        :too-many-attempts "You have made too many attempts to log in. Please try again later."
+        :username "Username"
+        :verify "Verify"
+        :welcome "Welcome"
+        }
+ :es
+ #:auth{
+        :welcome "Bienvenido"
+        }
+ }

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -326,7 +326,7 @@
         (db/transact conn [(assoc transaction
                                   :user/failed-login-count incremented)])))))
 
-(defmethod bread/dispatch ::login
+(defmethod bread/dispatch ::login=>
   [{:keys [params request-method session] :as req}]
   (let [{:auth/keys [step]} session
         max-failed-login-count (bread/config req :auth/max-failed-login-count)

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -197,7 +197,7 @@
         current-step (:auth/step session)
         login-step? (nil? current-step)
         two-factor-step? (= :two-factor current-step)
-        two-factor-enabled? (boolean (:user/two-factor-key user))
+        two-factor-enabled? (boolean (:user/totp-key user))
         next-step (if (and (not= :two-factor current-step) two-factor-enabled?)
                     :two-factor
                     :logged-in)
@@ -272,7 +272,7 @@
       (let [code (try
                    (Integer. two-factor-code)
                    (catch java.lang.NumberFormatException _ 0))
-            valid (totp/valid-code? (:user/two-factor-key user) code)]
+            valid (totp/valid-code? (:user/totp-key user) code)]
         {:valid valid :user user}))))
 
 (defmethod bread/action ::logout [res _ _]
@@ -336,7 +336,7 @@
                    (:username params))
         user-keys [:db/id
                    :user/username
-                   :user/two-factor-key
+                   :user/totp-key
                    :user/locked-at
                    :user/failed-login-count]
         user-keys (if two-factor? user-keys (concat user-keys [:user/password]))
@@ -424,9 +424,9 @@
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.authentication"}
-     {:db/ident :user/two-factor-key
-      :attr/label "2FA key"
-      :db/doc "User's 2FA secret key"
+     {:db/ident :user/totp-key
+      :attr/label "TOTP key"
+      :db/doc "User's secret key for the Time-based One-Time Password algorithm"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
       :attr/migration "migration.authentication"}

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -499,7 +499,7 @@
           max-failed-login-count 5
           lock-seconds 3600
           next-param :next
-          login-uri "/~/login"}}]
+          login-uri "/login"}}]
    {:hooks
     {::db/migrations
      [{:action/name ::migrations

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -479,7 +479,7 @@
           max-failed-login-count 5
           lock-seconds 3600
           next-param :next
-          login-uri "/login"}}]
+          login-uri "/~/login"}}]
    {:hooks
     {::db/migrations
      [{:action/name ::migrations

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -13,11 +13,14 @@
     [systems.bread.alpha.internal.time :as t]
     [systems.bread.alpha.ring :as ring])
   (:import
+    [java.lang IllegalArgumentException]
     [java.net URLEncoder]
     [java.util UUID]))
 
 (defn- ->uuid [x]
-  (if (string? x) (UUID/fromString x) x))
+  (if (string? x)
+    (try (UUID/fromString x) (catch IllegalArgumentException _ nil))
+    x))
 
 (deftype DatalogSessionStore [conn]
   SessionStore
@@ -48,7 +51,8 @@
   (URLEncoder/encode "/destination")
   (URLEncoder/encode "/destination?param=1")
   (URLEncoder/encode "/destination?param=1&b=2")
-  (str (UUID/fromString "6713c8ff-cca2-4e28-a2ac-a34f3745487b"))
+  (->uuid "bad")
+  (->uuid (str (UUID/fromString "6713c8ff-cca2-4e28-a2ac-a34f3745487b") "-extra"))
   (->uuid nil)
   (def totp-spec
     (totp/generate-key "Breadbox" "coby@tamayo.email"))

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -114,10 +114,10 @@
             font-weight: 700;
             color: var(--color-text-error);
             border: 2px dashed var(--color-text-error);
-            padding: 4px 8px;
+            padding: 8px;
           }
           input {
-            padding: 5px;
+            padding: 8px;
             border: 2px solid var(--color-text-body);
           }
           button, input {
@@ -127,7 +127,7 @@
             border-radius: 0;
           }
           button {
-            padding: 4px 10px;
+            padding: 4px 8px;
             cursor: pointer;
           }
           button:focus, input:focus {

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -61,12 +61,13 @@
   (totp/valid-code? (:secret-key totp-spec) 414903))
 
 (defc LoginPage
-  [{:keys [hook i18n session] :auth/keys [result] :as data}]
+  [{:keys [hook i18n session rtl? dir] :auth/keys [result] :as data}]
   {}
   (let [user (:user session)
         step (:auth/step session)
         error? (false? (:valid result))]
-    [:html {:lang "en"} ;; TODO
+    [:html {:lang (:field/lang data)
+            :dir dir}
      [:head
       [:meta {:content-type "utf-8"}]
       (hook ::html.title [:title (str (:auth/login i18n) " | Bread")])

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -77,8 +77,15 @@
             --color-text-body: hsl(120, 32.6%, 81.4%);
             --color-text-error: hsl(284.3, 75.5%, 79.2%);
             --color-emphasis: hsl(157.6, 85.6%, 49%);
-            --color-lighter hsl(157.6, 85.6%, 49%);
             --color-bg: hsl(264, 41.7%, 4.7%);
+          }
+          @media (prefers-color-scheme: light) {
+            :root {
+              --color-text-body: hsl(263.9, 79%, 24.3%);
+              --color-text-error: hsl(309.4, 73.8%, 37.5%);
+              --color-emphasis: hsl(157.4, 64.9%, 25.7%);
+              --color-bg: hsl(115.4, 61.9%, 95.9%);
+            }
           }
           body {
             width: 50ch;

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -136,6 +136,7 @@
           button {
             padding: 4px 8px;
             cursor: pointer;
+            font-weight: 700;
           }
           button:focus, input:focus {
             outline: 2px solid var(--color-emphasis);

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -75,6 +75,7 @@
           "
           :root {
             --color-text-body: hsl(120, 32.6%, 81.4%);
+            --color-text-error: hsl(284.3, 75.5%, 79.2%);
             --color-emphasis: hsl(157.6, 85.6%, 49%);
             --color-lighter hsl(157.6, 85.6%, 49%);
             --color-bg: hsl(264, 41.7%, 4.7%);
@@ -108,6 +109,12 @@
           }
           .field input {
             flex: 2;
+          }
+          .error {
+            font-weight: 700;
+            color: var(--color-text-error);
+            border: 2px dashed var(--color-text-error);
+            padding: 4px 8px;
           }
           input {
             padding: 5px;
@@ -159,8 +166,9 @@
            [:input {:id :two-factor-code :type :number :name :two-factor-code}]
            [:button {:type :submit :name :submit :value "verify"} "Verify"]]
           (when error?
-            [:div.error
-             [:p "Invalid code. Please try again."]])]]
+            (hook ::html.invalid-code
+                  [:div.error
+                   [:p "Invalid code. Please try again."]]))]]
 
         :default
         [:main
@@ -175,6 +183,10 @@
           [:div.field
            [:label {:for :password} "Password"]
            [:input {:id :password :type :password :name :password}]]
+          (when error?
+            (hook ::html.invalid-login
+                  [:div.error
+                   [:p "Invalid username or password."]]))
           [:div
            [:button {:type :submit} "Login"]]]])]]))
 

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -169,7 +169,7 @@
          [:form {:name :bread-logout :method :post}
           (hook ::html.login-heading [:h1 "Login to Bread"])
           (hook ::html.enter-2fa-code
-                [:p "Please enter the one-time code from your authenticator app."])
+                [:p.instruct "Please enter the one-time code from your authenticator app."])
           [:div.field.two-factor
            [:input {:id :two-factor-code :type :number :name :two-factor-code}]
            [:button {:type :submit :name :submit :value "verify"} "Verify"]]

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -201,6 +201,12 @@
   [req _ [params]]
   (assoc params (bread/config req :i18n/lang-param) (lang req)))
 
+(defmethod bread/action ::expand-global-strings
+  [req {:keys [global-strings]} _]
+  (expansion/add req {:expansion/key :i18n
+                      :expansion/name ::bread/value
+                      :expansion/value global-strings}))
+
 (defmethod bread/action ::add-strings-query
   [req _ _]
   (expansion/add req {:expansion/name ::db/query
@@ -225,11 +231,12 @@
 (defn plugin
   ([]
    (plugin {}))
-  ([{:keys [lang-param fallback-lang supported-langs
+  ([{:keys [lang-param fallback-lang supported-langs global-strings
             query-global-strings? query-lang? format-fields? compact-fields?]
      :or {lang-param      :field/lang
           fallback-lang   :en
           supported-langs #{:en}
+          global-strings {}
           query-global-strings?  true
           query-lang?     true
           format-fields?  true
@@ -248,7 +255,11 @@
      [{:action/name ::path-params
        :action/description "Get internationalized path params from route"}]
      ::bread/dispatch
-     [(when query-global-strings?
+     [(when global-strings
+        {:action/name ::expand-global-strings
+         :action/description "Add an expansion for globally configured strings."
+         :global-strings global-strings})
+      (when query-global-strings?
         {:action/name ::add-strings-query
          :action/description "Add global strings query"})
       (when query-lang?

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -205,7 +205,7 @@
   [req {:keys [global-strings]} _]
   (expansion/add req {:expansion/key :i18n
                       :expansion/name ::bread/value
-                      :expansion/value global-strings}))
+                      :expansion/value (get global-strings (lang req) {})}))
 
 (defmethod bread/action ::add-strings-query
   [req _ _]

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -230,7 +230,6 @@
      :or {lang-param      :field/lang
           fallback-lang   :en
           supported-langs #{:en}
-          ;; TODO query-global-strings?
           query-global-strings?  true
           query-lang?     true
           format-fields?  true

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -234,6 +234,12 @@
                                  (not-join [?e] [_ :thing/fields ?e])]}
                        (lang req)]}))
 
+(defmethod bread/action ::add-rtl-expansion
+  [req _ _]
+  (expansion/add req {:expansion/name ::bread/value
+                      :expansion/key :rtl?
+                      :expansion/value (rtl? req)}))
+
 (defmethod bread/action ::add-lang-query
   [req _ _]
   (expansion/add req {:expansion/name ::bread/value
@@ -271,7 +277,10 @@
      [{:action/name ::path-params
        :action/description "Get internationalized path params from route"}]
      ::bread/dispatch
-     [(when global-strings
+     [(when rtl-langs
+        {:action/name ::add-rtl-expansion
+         :action/description "Add an expansion for whether req lang is RTL."})
+      (when global-strings
         {:action/name ::expand-global-strings
          :action/description "Add an expansion for globally configured strings."
          :global-strings global-strings})

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -26,6 +26,12 @@
         lang (or supported (bread/config req :i18n/fallback-lang))]
     (bread/hook req ::lang lang)))
 
+(defn rtl?
+  "Whether the lang for the current request is written right-to-left according
+  to :i18n/rtl-langs config."
+  [req]
+  (contains? (bread/config req :i18n/rtl-langs) (lang req)))
+
 (defn lang-supported?
   "Whether lang has any translatable strings available. Does not necessarily
   indicate that all translatable strings have translations for lang."
@@ -238,7 +244,8 @@
   ([]
    (plugin {}))
   ([{:keys [lang-param fallback-lang supported-langs global-strings
-            query-global-strings? query-lang? format-fields? compact-fields?]
+            query-global-strings? query-lang? format-fields? compact-fields?
+            rtl-langs]
      :or {lang-param      :field/lang
           fallback-lang   :en
           supported-langs #{:en}
@@ -246,13 +253,16 @@
           query-global-strings?  true
           query-lang?     true
           format-fields?  true
-          compact-fields? true}}]
+          compact-fields? true
+          rtl-langs #{:ar :he :fa :ur :ps :yi :ku
+                      :sy :arc :dv :ug :sd :brh}}}]
    {:config
     {:i18n/lang-param      lang-param
      :i18n/fallback-lang   fallback-lang
      :i18n/supported-langs supported-langs
      :i18n/format-fields?  format-fields?
-     :i18n/compact-fields? compact-fields?}
+     :i18n/compact-fields? compact-fields?
+     :i18n/rtl-langs       rtl-langs}
     :hooks
     {::expansions
      [{:action/name ::expansions

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -203,9 +203,15 @@
 
 (defmethod bread/action ::expand-global-strings
   [req {:keys [global-strings]} _]
-  (expansion/add req {:expansion/key :i18n
-                      :expansion/name ::bread/value
-                      :expansion/value (get global-strings (lang req) {})}))
+  (let [strings (bread/hook req ::global-strings
+                            (get global-strings (lang req) {}))]
+    (expansion/add req {:expansion/key :i18n
+                        :expansion/name ::bread/value
+                        :expansion/value strings})))
+
+(defmethod bread/action ::merge-global-strings
+  [req {:keys [strings]} [req-strings]]
+  (merge req-strings (get strings (lang req))))
 
 (defmethod bread/action ::add-strings-query
   [req _ _]

--- a/src/systems/bread/alpha/i18n.cljc
+++ b/src/systems/bread/alpha/i18n.cljc
@@ -32,6 +32,12 @@
   [req]
   (contains? (bread/config req :i18n/rtl-langs) (lang req)))
 
+(defn dir
+  "Whether the lang for the current request is written right-to-left according
+  to :i18n/rtl-langs config."
+  [req]
+  (if (rtl? req) :rtl :ltr))
+
 (defn lang-supported?
   "Whether lang has any translatable strings available. Does not necessarily
   indicate that all translatable strings have translations for lang."
@@ -240,6 +246,12 @@
                       :expansion/key :rtl?
                       :expansion/value (rtl? req)}))
 
+(defmethod bread/action ::add-dir-expansion
+  [req _ _]
+  (expansion/add req {:expansion/name ::bread/value
+                      :expansion/key :dir
+                      :expansion/value (if (rtl? req) :rtl :ltr)}))
+
 (defmethod bread/action ::add-lang-query
   [req _ _]
   (expansion/add req {:expansion/name ::bread/value
@@ -280,6 +292,9 @@
      [(when rtl-langs
         {:action/name ::add-rtl-expansion
          :action/description "Add an expansion for whether req lang is RTL."})
+      (when rtl-langs
+        {:action/name ::add-dir-expansion
+         :action/description "Add an expansion for req text direction."})
       (when global-strings
         {:action/name ::expand-global-strings
          :action/description "Add an expansion for globally configured strings."

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -54,7 +54,7 @@
 
 (defmethod bread/action ::route
   [req _ _]
-  (assoc req ::bread/dispatcher {:dispatcher/type ::auth/login}))
+  (assoc req ::bread/dispatcher {:dispatcher/type ::auth/login=>}))
 
 (defn fake-2fa-validator
   ([^String _ ^long code]

--- a/test/cms/systems/bread/alpha/auth_test.clj
+++ b/test/cms/systems/bread/alpha/auth_test.clj
@@ -34,7 +34,7 @@
 (def douglass
   {:user/username "douglass"
    :user/failed-login-count 0
-   :user/two-factor-key "fake"})
+   :user/totp-key "fake"})
 
 (def config
   {:db/type :datahike

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -97,6 +97,31 @@
 
     ))
 
+(deftest test-dir
+  (are
+    [dir uri]
+    (= dir (let [handler (-> [(i18n/plugin {:supported-langs
+                                            #{:en :es :ar :he}
+                                            :query-global-strings? false})
+                              (route/plugin {:router (naive-router)})]
+                             plugins->loaded bread/handler)]
+             (i18n/dir (handler {:uri uri}))))
+
+    :ltr "/" ;; No lang route; Defaults to :ltr (:en)
+    :ltr "/qwerty" ;; Ditto.
+    :ltr "/en"
+    :ltr "/en/qwerty"
+    :ltr "/es"
+    :ltr "/es/qwerty"
+    :ltr "/fr" ;; Default to :en, since :fr is not in supported-langs
+    :ltr "/de" ;; Default to :en, since :de is not in supported-langs
+    :rtl "/ar"
+    :rtl "/ar/qwerty"
+    :rtl "/he"
+    :rtl "/he/qwerty"
+
+    ))
+
 (deftest test-strings-for
   (are
     [strings lang]

--- a/test/core/systems/bread/alpha/i18n_test.clj
+++ b/test/core/systems/bread/alpha/i18n_test.clj
@@ -72,6 +72,31 @@
 
     ))
 
+(deftest test-rtl?
+  (are
+    [rtl? uri]
+    (= rtl? (let [handler (-> [(i18n/plugin {:supported-langs
+                                             #{:en :es :ar :he}
+                                             :query-global-strings? false})
+                               (route/plugin {:router (naive-router)})]
+                              plugins->loaded bread/handler)]
+              (i18n/rtl? (handler {:uri uri}))))
+
+    false "/" ;; No lang route; Defaults to :en.
+    false "/qwerty" ;; Ditto.
+    false "/en"
+    false "/en/qwerty"
+    false "/es"
+    false "/es/qwerty"
+    false "/fr" ;; Default to :en, since :fr is not in supported-langs
+    false "/de" ;; Default to :en, since :de is not in supported-langs
+    true "/ar"
+    true "/ar/qwerty"
+    true "/he"
+    true "/he/qwerty"
+
+    ))
+
 (deftest test-strings-for
   (are
     [strings lang]

--- a/test/core/systems/bread/alpha/navigation_test.clj
+++ b/test/core/systems/bread/alpha/navigation_test.clj
@@ -28,7 +28,8 @@
     (= data (-> (plugins->loaded [(db->plugin ::FAKEDB)
                                   (route/plugin {:router (MockRouter.
                                                            req-params)})
-                                  (i18n/plugin {:global-strings nil
+                                  (i18n/plugin {:rtl-langs nil
+                                                :global-strings nil
                                                 :query-global-strings? false
                                                 :query-lang? false})
                                   (navigation/plugin config)])

--- a/test/core/systems/bread/alpha/navigation_test.clj
+++ b/test/core/systems/bread/alpha/navigation_test.clj
@@ -28,7 +28,8 @@
     (= data (-> (plugins->loaded [(db->plugin ::FAKEDB)
                                   (route/plugin {:router (MockRouter.
                                                            req-params)})
-                                  (i18n/plugin {:query-global-strings? false
+                                  (i18n/plugin {:global-strings nil
+                                                :query-global-strings? false
                                                 :query-lang? false})
                                   (navigation/plugin config)])
                 (bread/hook ::bread/dispatch)

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -46,7 +46,8 @@
   (let [attrs-map {:thing/fields {:db/cardinality :db.cardinality/many}
                    :post/taxons  {:db/cardinality :db.cardinality/many}}
         app (plugins->loaded [(db->plugin ::FAKEDB)
-                              (i18n/plugin {:query-global-strings? false
+                              (i18n/plugin {:global-strings nil
+                                            :query-global-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)
                               (route/plugin {:router (naive-router)})

--- a/test/core/systems/bread/alpha/post_test.clj
+++ b/test/core/systems/bread/alpha/post_test.clj
@@ -46,7 +46,8 @@
   (let [attrs-map {:thing/fields {:db/cardinality :db.cardinality/many}
                    :post/taxons  {:db/cardinality :db.cardinality/many}}
         app (plugins->loaded [(db->plugin ::FAKEDB)
-                              (i18n/plugin {:global-strings nil
+                              (i18n/plugin {:rtl-langs nil
+                                            :global-strings nil
                                             :query-global-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)

--- a/test/core/systems/bread/alpha/taxon_test.clj
+++ b/test/core/systems/bread/alpha/taxon_test.clj
@@ -16,7 +16,8 @@
   (let [attrs-map {:thing/fields {:db/cardinality :db.cardinality/many}
                    :post/taxons  {:db/cardinality :db.cardinality/many}}
         app (plugins->loaded [(db->plugin ::FAKEDB)
-                              (i18n/plugin {:query-global-strings? false
+                              (i18n/plugin {:global-strings nil
+                                            :query-global-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)
                               (route/plugin {:router (naive-router)})

--- a/test/core/systems/bread/alpha/taxon_test.clj
+++ b/test/core/systems/bread/alpha/taxon_test.clj
@@ -16,7 +16,8 @@
   (let [attrs-map {:thing/fields {:db/cardinality :db.cardinality/many}
                    :post/taxons  {:db/cardinality :db.cardinality/many}}
         app (plugins->loaded [(db->plugin ::FAKEDB)
-                              (i18n/plugin {:global-strings nil
+                              (i18n/plugin {:rtl-langs nil
+                                            :global-strings nil
                                             :query-global-strings? false
                                             :query-lang? false})
                               (dispatcher/plugin)


### PR DESCRIPTION
- Support setting `global-strings` in config
- Honor `accept-language` header
- Add `i18n/dir` and `i18n/rtl?` helpers
- Add ^ corresponding keys to `::bread/data`
- Translations for auth