### PR TITLE
Semi-working installer

### DIFF
--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -23,6 +23,7 @@
     [systems.bread.alpha.defaults :as defaults]
     [systems.bread.alpha.ring :as bread.ring]
     [systems.bread.alpha.user :as user]
+    [systems.bread.alpha.util.logging :refer [log-redactor]]
     [systems.bread.alpha.cms.config.bread]
     [systems.bread.alpha.cms.config.buddy]
     [systems.bread.alpha.cms.config.reitit]
@@ -38,6 +39,9 @@
     [java.time LocalDateTime]
     [java.util Date Properties UUID])
   (:gen-class))
+
+(log/merge-config! {:min-level (keyword (or (System/getenv "BREAD_LOG_LEVEL") :info))
+                    :middleware [(log-redactor)]})
 
 (def cli-options
   [["-h" "--help"

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -12,7 +12,6 @@
     [ring.middleware.defaults :as ring]
     [sci.core :as sci]
     [taoensso.timbre :as log]
-    ;; TODO ring middlewares
 
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.cms.theme :as theme]

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -315,7 +315,7 @@
 
 (defmethod ig/init-key :bread/db
   [_ {:keys [recreate? force?] :as db-config}]
-  (log/info "initializing :bread/db with config:" db-config)
+  (log/debug "initializing :bread/db with config:" db-config)
   ;; TODO call datahike API directly
   (db/create! db-config {:force? force?})
   (assoc db-config :db/connection (db/connect db-config)))

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -40,9 +40,6 @@
     [java.util Date Properties UUID])
   (:gen-class))
 
-(log/merge-config! {:min-level (keyword (or (System/getenv "BREAD_LOG_LEVEL") :info))
-                    :middleware [(log-redactor)]})
-
 (def cli-options
   [["-h" "--help"
     "Show this usage text."]
@@ -191,6 +188,10 @@
 
 (defmethod ig/init-key :started-at [_ _]
   (LocalDateTime/now))
+
+(defmethod ig/init-key :app/log [_ log-config]
+  (log/merge-config! {:min-level (:min-level log-config :info)
+                      :middleware [(log-redactor)]}))
 
 (defn- wrap-clear-flash [f]
   (fn [req]

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -52,7 +52,7 @@
     :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536."]]
    ["-f" "--file FILE"
     "Config file path. Ignored if --file is passed."
-    :default "config.edn"]
+    :default "bread.edn"]
    ["-c" "--config EDN"
     "Full configuration data as EDN. Causes other args to be ignored."
     :parse-fn edn/read-string]

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -21,6 +21,7 @@
     [systems.bread.alpha.thing :as thing]
     [systems.bread.alpha.database :as db]
     [systems.bread.alpha.defaults :as defaults]
+    [systems.bread.alpha.ring :as bread.ring]
     [systems.bread.alpha.user :as user]
     [systems.bread.alpha.cms.config.bread]
     [systems.bread.alpha.cms.config.buddy]
@@ -37,12 +38,6 @@
     [java.time LocalDateTime]
     [java.util Date Properties UUID])
   (:gen-class))
-
-(def status-mappings
-  {200 "OK"
-   400 "Bad Request"
-   404 "Not Found"
-   500 "Internal Server Error"})
 
 (def cli-options
   [["-h" "--help"
@@ -93,7 +88,7 @@
                :content-length (Integer.
                                  (or (System/getenv "CONTENT_LENGTH") "0"))}
           {:keys [status headers body] :as res} (handler req)]
-      (println (str "status: " status " " (status-mappings status)))
+      (println (str "status: " status " " (bread.ring/http-status-codes status)))
       (doseq [[header header-value] headers]
         (println (str header ": " header-value)))
       (println)

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -107,7 +107,13 @@
     :default false]
    ["-g" "--cgi"
     "Run Bread as a CGI script"
-    :default false]])
+    :default false]
+   ["-v" "--log-level LEVEL"
+    "Set log verbosity"
+    :parse-fn keyword
+    :default :info
+    :validate [#{:trace :debug :info :warn :error :fatal :report}
+               "Must be one of: trace, debug, info, warn, error, fatal, report"]]])
 
 (defn show-help [{:keys [summary]}]
   (println summary))
@@ -198,7 +204,7 @@
               admin-password (prompt-cli-user-for-password i18n)
               _ (let [detail-lines [[:username admin-username]]]
                   (println)
-                  (doseq [[k v] [[:username "coby"]]]
+                  (doseq [[k v] detail-lines]
                     ;; TODO how to handle ":" in RTL???
                     (println (bold (k i18n) ":") v))
                   (println)

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -193,9 +193,11 @@
 (def red (partial style :red))
 
 (defn run-install [{:keys [options i18n]}]
-  (let [config (-> (get-config options)
+  (let [log-level (:log-level options)
+        config (-> (get-config options)
                    (select-keys [:bread/db :bread/app :app/log])
-                   (update :bread/router #(or % router)))]
+                   (update :bread/router #(or % router)))
+        config (if log-level (assoc-in config [:app/log :min-level] log-level) config)]
     (when (= :mem (get-in config [:bread/db :store :backend]))
       (println (bold (red (:warning-backend-mem i18n)))))
     (loop [confirmed-details nil]

--- a/cms/systems/bread/alpha/cms/main.cljc
+++ b/cms/systems/bread/alpha/cms/main.cljc
@@ -44,11 +44,14 @@
    500 "Internal Server Error"})
 
 (def cli-options
-  [["-h" "--help" "Show this usage text."]
-   ["-p" "--port PORT" "Port number to run the HTTP server on."
+  [["-h" "--help"
+    "Show this usage text."]
+   ["-p" "--port PORT"
+    "Port number to run the HTTP server on."
     :parse-fn #(Integer/parseInt %)
     :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536."]]
-   ["-f" "--file FILE" "Config file path. Ignored if --file is passed."
+   ["-f" "--file FILE"
+    "Config file path. Ignored if --file is passed."
     :default "config.edn"]
    ["-c" "--config EDN"
     "Full configuration data as EDN. Causes other args to be ignored."

--- a/deps.edn
+++ b/deps.edn
@@ -58,7 +58,9 @@
                 org.xerial/sqlite-jdbc      {:mvn/version "3.41.0.0"}
                 ring/ring                   {:mvn/version "1.9.5"}
                 ring/ring-defaults          {:mvn/version "0.4.0"}
-                rum/rum                     {:mvn/version "0.12.10"}}}
+                rum/rum                     {:mvn/version "0.12.10"}
+                com.taoensso/timbre         {:mvn/version "6.7.1"}
+                ,}}
 
   :marx
   {:extra-paths ["marx" "marx/out"]

--- a/dev/main.edn
+++ b/dev/main.edn
@@ -61,7 +61,11 @@
                 :role/abilities
                 #{{:ability/key :publish-posts}
                   {:ability/key :edit-posts}
-                  {:ability/key :delete-posts}}}}}]]}
+                  {:ability/key :delete-posts}}}}}]]
+  ;; db logs can be noisy, so load logging config first
+  :__after #ig/ref :app/log}
+ :app/log
+ {:min-level :info}
  #_#_
  :bread/profilers
  [{:hook #{:systems.bread.alpha.core/request}

--- a/plugins/auth/systems/bread/alpha/plugin/auth.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/auth.cljc
@@ -645,12 +645,14 @@
       :db/doc "User account password hash"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
+      :attr/sensitive? true
       :attr/migration "migration.authentication"}
      {:db/ident :user/totp-key
       :attr/label "TOTP key"
       :db/doc "User's secret key for the Time-based One-Time Password algorithm"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one
+      :attr/sensitive? true
       :attr/migration "migration.authentication"}
      {:db/ident :user/locked-at
       :attr/label "Account Locked-at Time"
@@ -678,6 +680,7 @@
       :db/valueType :db.type/string
       :db/unique :db.unique/identity
       :db/cardinality :db.cardinality/one
+      :attr/sensitive? true
       :attr/migration "migration.authentication"}
      {:db/ident :session/data
       :attr/label "Session Data"

--- a/src/systems/bread/alpha/database.cljc
+++ b/src/systems/bread/alpha/database.cljc
@@ -160,6 +160,8 @@
                           {:unmet-deps (set unmet-deps)})))
         (mark-sensitive-attrs! migration)
         (when-not (migration-ran? (database app) migration)
+          (log/info "db migration ran" (:migration/key (first (filter :migration/key migration))))
+          (log/debug "migration installed schema" migration)
           (transact conn migration)))))
   app)
 

--- a/src/systems/bread/alpha/database.cljc
+++ b/src/systems/bread/alpha/database.cljc
@@ -2,6 +2,7 @@
   (:require
     [clojure.core.protocols :refer [datafy]]
     [clojure.spec.alpha :as spec]
+    [taoensso.timbre :as log]
     [systems.bread.alpha.core :as bread]
     [systems.bread.alpha.schema :as schema]
     [systems.bread.alpha.util.logging :refer [mark-sensitve-keys!]]

--- a/src/systems/bread/alpha/ring.cljc
+++ b/src/systems/bread/alpha/ring.cljc
@@ -2,6 +2,80 @@
   (:require
     [systems.bread.alpha.core :as bread]))
 
+(def http-status-codes
+  {;; 1xx Informational
+   100 "Continue"
+   101 "Switching Protocols"
+   102 "Processing"
+   103 "Early Hints"
+
+   ;; 2xx Success
+   200 "OK"
+   201 "Created"
+   202 "Accepted"
+   203 "Non-Authoritative Information"
+   204 "No Content"
+   205 "Reset Content"
+   206 "Partial Content"
+   207 "Multi-Status"
+   208 "Already Reported"
+   226 "IM Used"
+
+   ;; 3xx Redirection
+   300 "Multiple Choices"
+   301 "Moved Permanently"
+   302 "Found"
+   303 "See Other"
+   304 "Not Modified"
+   305 "Use Proxy"
+   ;; 306 - no longer used, but reserved.
+   307 "Temporary Redirect"
+   308 "Permanent Redirect"
+
+   ;; 4xx Client Error
+   400 "Bad Request"
+   401 "Unauthorized"
+   402 "Payment Required"
+   403 "Forbidden"
+   404 "Not Found"
+   405 "Method Not Allowed"
+   406 "Not Acceptable"
+   407 "Proxy Authentication Required"
+   408 "Request Timeout"
+   409 "Conflict"
+   410 "Gone"
+   411 "Length Required"
+   412 "Precondition Failed"
+   413 "Payload Too Large"
+   414 "URI Too Long"
+   415 "Unsupported Media Type"
+   416 "Range Not Satisfiable"
+   417 "Expectation Failed"
+   418 "I'm a teapot"
+   421 "Misdirected Request"
+   422 "Unprocessable Content"
+   423 "Locked"
+   424 "Failed Dependency"
+   425 "Too Early"
+   426 "Upgrade Required"
+   428 "Precondition Required"
+   429 "Too Many Requests"
+   431 "Request Header Fields Too Large"
+   451 "Unavailable For Legal Reasons"
+
+   ;; 5xx Server Error
+   500 "Internal Server Error"
+   501 "Not Implemented"
+   502 "Bad Gateway"
+   503 "Service Unavailable"
+   504 "Gateway Timeout"
+   505 "HTTP Version Not Supported"
+   506 "Variant Also Negotiates"
+   507 "Insufficient Storage"
+   508 "Loop Detected"
+   510 "Not Extended"
+   511 "Network Authentication Required"})
+
 (defmethod bread/action ::request-data
   [req _ _]
   (let [req-keys (bread/hook req ::request-keys [:ring/content-length

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -22,6 +22,10 @@
       :db/doc "Human-readable label for the database attr itself"
       :db/valueType :db.type/string
       :db/cardinality :db.cardinality/one}
+     {:db/ident :attr/sensitive?
+      :db/doc "Whether values of this attr are considered sensitive (e.g. :user/password)"
+      :db/valueType :db.type/boolean
+      :db/cardinality :db.cardinality/one}
      {:migration/key :bread.migration/migrations
       :migration/description
       "Minimal schema for safely performing future migrations."}]

--- a/src/systems/bread/alpha/schema.cljc
+++ b/src/systems/bread/alpha/schema.cljc
@@ -241,7 +241,7 @@
                                :bread.migration/users}}))
 
 (def
-  ^{:doc "Minimal schema for posts, the central concept of Bread CMS."}
+  ^{:doc "Minimal schema for posts, the central content type of Bread CMS."}
   posts
   (with-meta
     [{:db/id "migration.posts"

--- a/src/systems/bread/alpha/util/logging.cljc
+++ b/src/systems/bread/alpha/util/logging.cljc
@@ -3,7 +3,7 @@
   (:require
     [clojure.walk :as walk]))
 
-(def ^:dynamic ^:private *sensitive-keys* #{})
+(def ^:dynamic ^:private *sensitive-keys* #{:user/password :user/totp-key :session/id})
 
 (defn log-redactor
   ([]

--- a/src/systems/bread/alpha/util/logging.cljc
+++ b/src/systems/bread/alpha/util/logging.cljc
@@ -1,0 +1,30 @@
+(ns systems.bread.alpha.util.logging
+  "Logging helper utilities."
+  (:require
+    [clojure.walk :as walk]))
+
+(def ^:dynamic ^:private *sensitive-keys* #{})
+
+(defn log-redactor
+  ([]
+   (log-redactor {}))
+  ([{:keys [redacted] :or {redacted "[REDACTED]"}}]
+   (fn [data]
+     (walk/postwalk (fn [node]
+                      (if-let [ks (and (map? node) (seq (keys (select-keys node *sensitive-keys*))))]
+                        (into node (zipmap ks (repeat redacted)))
+                        node))
+                    data))))
+
+(defn mark-sensitve-keys! [& ks]
+  (alter-var-root #'*sensitive-keys* #(apply conj % ks)))
+
+(comment
+  (def bobby {:name "bobby" :secret "don't tell!" :new-secret "me neither"})
+  (def secret-redactor (log-redactor))
+  (secret-redactor bobby)
+  (mark-sensitve-keys! :secret)
+  (mark-sensitve-keys! :secret :new-secret)
+
+  (secret-redactor {:user/password "secret!!!"})
+  ,)


### PR DESCRIPTION
Functionality for the CLI installer. Persistence through SQLite is still not working.

Also creates logging with Timbre. Adds a `:attr/sensitive?` db attr and automatic redaction from logs for all attrs for which `:attr/sensitive?` is true.