### PR TITLE
Bugfix: invitations

### DIFF
--- a/plugins/auth/systems/bread/alpha/plugin/invitations.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/invitations.cljc
@@ -185,7 +185,7 @@
     {:flash {:error-key error-key}}))
 
 (defmethod bread/dispatch ::invitations=>
-  [{:keys [::bread/dispatcher params request-method server-name]
+  [{:keys [::bread/dispatcher params request-method]
     {:keys [user]} :session
     :as req}]
   "Invitations page in the account section"

--- a/plugins/auth/systems/bread/alpha/plugin/invitations.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/invitations.cljc
@@ -115,12 +115,12 @@
        :message message}]}))
 
 (defmethod bread/effect [::invite :send] send-invitation
-  [{:keys [conn params]} {:keys [user] [valid? error-key] :validation}]
+  [{:keys [conn params secret-key]} {:keys [user] [valid? error-key] :validation}]
   (if valid?
     (let [email (:email params)
           code (random/url-part 32)
           now (t/now)
-          invitation-tx {:invitation/code (sha-512 code)
+          invitation-tx {:invitation/code (sha-512 (str secret-key ":" code))
                          :invitation/invited-by (:db/id user)
                          :invitation/email {:email/address email
                                             :thing/created-at now
@@ -144,13 +144,13 @@
     {:flash {:error-key error-key}}))
 
 (defmethod bread/effect [::invite :resend] resend-invitation
-  [{:keys [conn params]} {:keys [user] [valid? error-key] :validation}]
+  [{:keys [conn params secret-key]} {:keys [user] [valid? error-key] :validation}]
   (if valid?
     (let [id (->int (:id params))
           code (random/url-part 32)
           now (t/now)
           invitation-tx {:db/id id
-                         :invitation/code (sha-512 code)
+                         :invitation/code (sha-512 (str secret-key ":" code))
                          :thing/updated-at now}
           invitation (first (filter #(= id (:db/id %)) (:invitation/_invited-by user)))
           to (:email/address (:invitation/email invitation))
@@ -218,6 +218,7 @@
          :effect/description "Email an invitation, pending validation."
          :effect/key action
          :params params
+         :secret-key (bread/config req :auth/secret-key)
          :conn (db/connection req)}]
        :hooks
        {::bread/render

--- a/plugins/auth/systems/bread/alpha/plugin/signup.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/signup.cljc
@@ -53,7 +53,9 @@
   (when valid?
     (if invitation
       (let [email (when-let [email (:invitation/email invitation)]
-                    (assoc email :email/confirmed-at (t/now)))
+                    (assoc email
+                           :email/confirmed-at (t/now)
+                           :email/primary? true))
             user (if email
                    (assoc user :user/emails [email])
                    user)]

--- a/plugins/auth/systems/bread/alpha/plugin/signup.cljc
+++ b/plugins/auth/systems/bread/alpha/plugin/signup.cljc
@@ -64,7 +64,7 @@
                            :invitation/redeemer user}]}]})
       {:effects [{:effect/name ::db/transact
                   :conn conn
-                  :effect/description "Create user"
+                  :effect/description "Create user."
                   :txs [user]}]})))
 
 (defmethod bread/action ::render

--- a/test/cms/systems/bread/alpha/plugin/signup_test.clj
+++ b/test/cms/systems/bread/alpha/plugin/signup_test.clj
@@ -394,7 +394,8 @@
                          {:user/username "test"
                           :user/password "<HASHED PASSWORD>"
                           :user/emails [{:email/address "user@example.com"
-                                         :email/confirmed-at !now}]
+                                         :email/confirmed-at !now
+                                         :email/primary? true}]
                           :thing/created-at ::NOW}}]
                   :conn ::DBCONN}]}
       {:effect/name ::signup/enact-valid-signup

--- a/test/cms/systems/bread/alpha/plugin/signup_test.clj
+++ b/test/cms/systems/bread/alpha/plugin/signup_test.clj
@@ -358,6 +358,56 @@
 
     ,))
 
+(deftest test-enact-valid-signup
+  (let [!now (Date.)]
+    (are
+      [expected effect data]
+      (= expected (binding [t/*now* !now]
+                    (bread/effect effect data)))
+
+      nil {:effect/name ::signup/enact-valid-signup} nil
+      nil {:effect/name ::signup/enact-valid-signup} {}
+      nil {:effect/name ::signup/enact-valid-signup} {:validation nil}
+      nil {:effect/name ::signup/enact-valid-signup} {:validation []}
+      nil {:effect/name ::signup/enact-valid-signup} {:validation [false]}
+      nil {:effect/name ::signup/enact-valid-signup} {:validation [false :whatever]}
+
+      ;; Open signup - not by invite.
+      {:effects [{:effect/name ::db/transact
+                  :effect/description "Create user."
+                  :txs [{:user/username "test"
+                         :user/password "<HASHED PASSWORD>"
+                         :thing/created-at !now}]
+                  :conn ::DBCONN}]}
+      {:effect/name ::signup/enact-valid-signup
+       :user {:user/username "test"
+              :user/password "<HASHED PASSWORD>"
+              :thing/created-at !now}
+       :conn ::DBCONN}
+      {:validation [true nil]}
+
+      ;; By invitation.
+      {:effects [{:effect/name ::db/transact
+                  :effect/description "Redeem invitation and create user."
+                  :txs [{:invitation/code "<HASHED CODE>"
+                         :invitation/redeemer
+                         {:user/username "test"
+                          :user/password "<HASHED PASSWORD>"
+                          :user/emails [{:email/address "user@example.com"
+                                         :email/confirmed-at !now}]
+                          :thing/created-at ::NOW}}]
+                  :conn ::DBCONN}]}
+      {:effect/name ::signup/enact-valid-signup
+       :user {:user/username "test"
+              :user/password "<HASHED PASSWORD>"
+              :thing/created-at ::NOW}
+       :conn ::DBCONN}
+      {:validation [true nil]
+       :invitation {:invitation/code "<HASHED CODE>"
+                    :invitation/email {:email/address "user@example.com"}}}
+
+      ,)))
+
 (deftest test-signup-render
   (are
     [expected action res]


### PR DESCRIPTION
- Hash invitations using `:auth/secret-key`, but actually
- Always mark initial emails in redeemed invitations as primary, fixing an issue preventing Forgot password from working